### PR TITLE
Optimize report requests

### DIFF
--- a/hackage-matrix-builder.cabal
+++ b/hackage-matrix-builder.cabal
@@ -64,6 +64,8 @@ library
     binary             >=0.7  && <0.8,
     blaze-builder      >=0.3  && <0.5,
     bytestring         >=0.10 && <0.11,
+    conduit            >=1.2  && <1.3,
+    conduit-extra      >=1.1  && <1.2,
     containers         >=0.5  && <0.6,
     cryptohash         >=0.11 && <0.12,
     deepseq            >=1.4  && <1.5,
@@ -84,6 +86,7 @@ library
     rest-core          >=0.35 && <0.37,
     rest-gen           >=0.17 && <0.18,
     rest-happstack     >=0.2  && <0.3,
+    resourcet          >=1.1  && <1.2,
     rest-stringmap     >=0.2  && <0.3,
     safe               >=0.3  && <0.4,
     shake              >=0.15 && <0.16,
@@ -93,6 +96,7 @@ library
     text-binary        >=0.1  && <0.3,
     time               >=1.5  && <1.6,
     tostring           >=0.2  && <0.3,
+    transformers       >=0.4  && <0.5,
     transformers-base  >=0.4  && <0.5,
     xmlhtml            >=0.2  && <0.3
 

--- a/hackage-matrix-builder.cabal
+++ b/hackage-matrix-builder.cabal
@@ -37,6 +37,7 @@ library
     Api
     Api.Package
     Api.Package.Report
+    Api.Package.Report.Cell
     Api.Queue
     Api.Root
     Api.Tag

--- a/src/Api.hs
+++ b/src/Api.hs
@@ -2,12 +2,13 @@ module Api (api) where
 
 import           Rest.Api
 
-import qualified Api.Package        as Package
-import qualified Api.Package.Report as Package.Report
-import qualified Api.Queue          as Queue
-import           Api.Root           (Root)
-import qualified Api.Tag            as Tag
-import qualified Api.User           as User
+import qualified Api.Package             as Package
+import qualified Api.Package.Report      as Package.Report
+import qualified Api.Package.Report.Cell as Package.Report.Cell
+import qualified Api.Queue               as Queue
+import           Api.Root                (Root)
+import qualified Api.Tag                 as Tag
+import qualified Api.User                as User
 
 api :: Api Root
 api = [(mkVersion 1 0 0, Some1 router)]
@@ -15,7 +16,7 @@ api = [(mkVersion 1 0 0, Some1 router)]
     router :: Router Root Root
     router =
       root -/ route queue
-           -/ route package --/ route report
+           -/ route package --/ route report ---/ route cell
            -/ route tag
            -/ route user
     package = Package.resource
@@ -23,3 +24,4 @@ api = [(mkVersion 1 0 0, Some1 router)]
     report  = Package.Report.resource
     tag     = Tag.resource
     user    = User.resource
+    cell    = Package.Report.Cell.resource

--- a/src/Api/Package.hs
+++ b/src/Api/Package.hs
@@ -104,7 +104,7 @@ reportsByStamp
       , rmModified    = b
       }
 
-validatePackage :: MonadRoot m => PackageName -> ExceptT Reason_ m ()
+validatePackage :: MonadRoot m => PackageName -> ExceptT (Reason e) m ()
 validatePackage pkgName =
   bool (throwError NotFound) (return ()) . (pkgName `elem`) =<< loadPackageSummary
 

--- a/src/Api/Package/Report/Cell.hs
+++ b/src/Api/Package/Report/Cell.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+module Api.Package.Report.Cell (resource) where
+
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Data.List
+import           Data.List.Split         (splitOn)
+import           Data.String.Conversions
+import           Rest
+import qualified Rest.Resource           as R
+
+import           Api.Package             (validatePackage)
+import           Api.Package.Report      (WithReport, readReport)
+import           Api.Types
+
+data Cell = Cell
+  { gvGhcVersion     :: VersionName
+  , gvPackageVersion :: VersionName
+  } deriving (Eq, Show)
+
+toCell :: String -> Maybe Cell
+toCell s =
+  case splitOn "/" s of
+    (a:b:_) -> Just Cell
+      { gvGhcVersion     = cs a
+      , gvPackageVersion = cs b
+      }
+    _          -> Nothing
+
+type WithCell = ReaderT (Maybe Cell) WithReport
+
+resource :: Resource WithReport WithCell (Maybe Cell) Void Void
+resource = mkResourceReader
+  { R.name   = "cell"
+  , R.schema = noListing $ named [("id", singleBy toCell)]
+  , R.get    = Just get
+  }
+
+get :: Handler WithCell
+get = mkConstHandler jsonO handler
+  where
+    handler :: ExceptT Reason_ WithCell SingleResult
+    handler = do
+      pkgName   <- lift . lift . lift $ ask
+      cell <- ask `orThrow` NotFound
+      validatePackage pkgName
+      report <- readReport pkgName `orThrow` NotFound
+      return (byGhcVersion cell report) `orThrow` NotFound
+
+byGhcVersion :: Cell -> Report -> Maybe SingleResult
+byGhcVersion cell
+  = fmap (toSingleResult $ gvPackageVersion cell)
+  . find ((== gvGhcVersion cell) . ghcVersion)
+  . rResults
+
+toSingleResult :: VersionName -> GHCResult -> SingleResult
+toSingleResult versionName gr = SingleResult
+  { srGhcVersion     = ghcVersion gr
+  , srGhcFullVersion = ghcFullVersion gr
+  , srResultA       = find ((== versionName) . packageVersion) (resultsA gr)
+  }

--- a/src/Identifiers.hs
+++ b/src/Identifiers.hs
@@ -28,6 +28,12 @@ type WithPackage = ReaderT PackageName Root
 newtype VersionName = VersionName { unVersionName :: StrictText }
   deriving (Eq, FromJSON, IsString, JSONSchema, Ord, Show, ToJSON)
 
+-- TODO These should use a smart constructor validating the format.
+instance ConvertibleStrings StrictText VersionName where
+  convertString = VersionName
+instance ConvertibleStrings String VersionName where
+  convertString = VersionName . cs
+
 newtype Revision = Revision { unRevision :: Word }
   deriving (Eq, FromJSON, JSONSchema, Ord, Show, ToJSON)
 

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -638,19 +638,24 @@
                    .get( function success (s) { setupFailTabs(ghcVersion, pkgName, packageVersion, s.resultA.result.fail); }
 
                        , function fail    (f) { console.warn("Loading cell data failed for " + ident, arguments) }
-                       )
+                       );
                 setHash(cellHash(ghcVersion, pkgName, packageVersion));
               });
           })(r);
         } else if (r = res.failDeps) {
           (function () {
-            td.text("FAIL (" + r.length + " deps)")
+            td.text("FAIL (" + r + " deps)")
               .addClass("fail-dep-build")
               .click(function (e) {
                 var ghcVersion = $(e.target).attr("data-ghc-version");
                 var packageVersion = $(e.target).attr("data-package-version");
+                var ident = ghcVersion + "/" + packageVersion;
+                api.Package.byName(pkgName).Report.latest().Cell.byId(ident)
+                   .get( function success (s) { setupFailDepsTabs(ghcVersion, s.resultA.result.failDeps); }
+
+                       , function fail    (f) { console.warn("Loading cell data failed for " + ident, arguments) }
+                       );
                 setHash(cellHash(ghcVersion, pkgName, packageVersion));
-                setupFailDepsTabs(ghcVersion, r);
               });
           })(r);
         } else if (res.nop) {
@@ -691,6 +696,7 @@
         var ghcVersion     = RegExp.$1;
         var packageVersion = RegExp.$2;
         var ghcVer = report.results.filter(function (v) { return v.ghcVersion === ghcVersion; })[0];
+        var ident = ghcVer.ghcVersion + "/" + packageVersion;
         if (!ghcVer) {
           console.warn("Could not find ghc version: GHC-" + ghcVersion);
           return;
@@ -702,14 +708,16 @@
           return;
         }
         if (res.result.fail) {
-          var ident = ghcVer.ghcVersion + "/" + packageVersion;
           api.Package.byName(pkgName).Report.latest().Cell.byId(ident).get
             ( function success (r) { setupFailTabs(ghcVer, pkgName, packageVersion, r.resultA.result.fail); }
             , function fail () { console.warn("Couldn't find cell data for " + ident, arguments); }
             );
         }
         else if (res.result.failDeps) {
-          setupFailDepsTabs(ghcVersion, res.result.failDeps);
+          api.Package.byName(pkgName).Report.latest().Cell.byId(ident)
+             .get( function success (s) { setupFailDepsTabs(ghcVersion, s.resultA.result.failDeps); }
+                 , function fail    (f) { console.warn("Couldn't load cell data failed for " + ident, arguments) }
+                 );
         } else {
           console.warn("No build failure found for: GHC-" + ghcVersion + "/" + pkgName + "-" + packageVersion);
         }


### PR DESCRIPTION
This change allows requests of a single build result identified by GHC version + package version and
changes the normal report format to not not include logs. 

It will be interesting to see if this is significant. If it is we could improve this in other ways, like caching this minified result by just writing it somewhere and updating if a newer build report exists.

I also just realized another big client side slow down is because  the entire package list gets loaded, I'll try to fix that as well.

Example, hfsevents report json:

``` json
{"results":
[{ "ghcResult":
  [ {"packageVersion":"0.1","result":{"fail":{}},"packageRevision":0}
  , {"packageVersion":"0.1.1","result":{"fail":{}},"packageRevision":0}
  , {"packageVersion":"0.1.2","result":{"fail":{}},"packageRevision":0}
  , {"packageVersion":"0.1.3","result":{"fail":{}},"packageRevision":0}
  , {"packageVersion":"0.1.4","result":{"fail":{}},"packageRevision":0}
  , {"packageVersion":"0.1.5","result":{"fail":{}},"packageRevision":0}
  ], "ghcVersion":"7.0", "ghcFullVersion":"7.0.4" }
, {"ghcResult":[{"packageVersion":"0.1","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.1","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.2","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.3","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.4","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.5","result":{"fail":{}},"packageRevision":0}],"ghcVersion":"7.2","ghcFullVersion":"7.2.2"}
, {"ghcResult":[{"packageVersion":"0.1","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.1","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.2","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.3","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.4","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.5","result":{"ok":{}},"packageRevision":0}],"ghcVersion":"7.4","ghcFullVersion":"7.4.2"}
, {"ghcResult":[{"packageVersion":"0.1","result":{"fail":{}},"packageRevision":0}
, {"packageVersion":"0.1.1","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.2","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.3","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.4","result":{"ok":{}},"packageRevision":0}
, {"packageVersion":"0.1.5","result":{"ok":{}},"packageRevision":0}],"ghcVersion":"7.6","ghcFullVersion":"7.6.3"}
, {"ghcResult":[{"packageVersion":"0.1","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.1","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.2","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.3","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.4","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.5","result":{"ok":{}},"packageRevision":0}],"ghcVersion":"7.8","ghcFullVersion":"7.8.4"}
, {"ghcResult":[{"packageVersion":"0.1","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.1","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.2","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.3","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.4","result":{"noIp":{}},"packageRevision":0}
, {"packageVersion":"0.1.5","result":{"ok":{}},"packageRevision":0
}]
,"ghcVersion":"7.10","ghcFullVersion":"7.10.2"}],"packageName":"hfsevents","modified":"2015-11-01T14:30:44.000000000000Z"}
```
