### PR TITLE
Update to the soon to be home for the trustee policy document

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -97,7 +97,7 @@
 
           <h3>Documents</h3>
           <ul>
-            <li><a href="https://gist.github.com/bergmark/76cafefb300546e9b90e">Draft Hackage trustee policy and procedures</a></li>
+            <li><a href="https://github.com/haskell-infra/hackage-trustees/blob/master/policy.md">Hackage trustee policy and procedures</a></li>
             <li><a href="https://wiki.haskell.org/Taking_over_a_package">Wiki: Taking over a package</a></li>
             <li><a href="https://wiki.haskell.org/Hackage_trustees">Wiki: Hackage Trustee</a></li>
           </ul>


### PR DESCRIPTION
A PR since https://github.com/haskell-infra/hackage-trustees/pull/61 isn't merged yet.
