### PR TITLE
PagePackages ready for Api v2

### DIFF
--- a/src-ui/src/Components/PageLatest.purs
+++ b/src-ui/src/Components/PageLatest.purs
@@ -6,6 +6,7 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Lib.MatrixApi2 as Api
 import Lib.MatrixApi as Api1
+import Lib.MiscFFI as Misc
 import Lib.Types as T
 import Data.Maybe (Maybe(..))
 import Prelude (type (~>), Unit, Void, bind, const, pure, show, otherwise, ($), (+), (-), (<$>), (<>), (<), (==))
@@ -137,7 +138,7 @@ renderTableQueue :: forall p. State
 renderTableQueue state num { pkgname, priority, idxstate } =
   { accum: num + 1
   , value: HH.tr
-             [ HP.class_ (H.ClassName (showPrio priority)) ] $
+             [ HP.class_ (H.ClassName (Misc.showPrio priority)) ] $
              [ HH.td
                  [ HP.class_ (H.ClassName "num") ]
                  [ HH.text $ show num ]
@@ -149,8 +150,8 @@ renderTableQueue state num { pkgname, priority, idxstate } =
                      [HH.text $ pkgname]
                  ]
              , HH.td
-                 [ HP.classes (H.ClassName <$> ["priority", (showPrio priority) ]) ]
-                 [ HH.text $ (showPrio priority) ]
+                 [ HP.classes (H.ClassName <$> ["priority", (Misc.showPrio priority) ]) ]
+                 [ HH.text $ (Misc.showPrio priority) ]
              , HH.td
                  [ HE.onClick $ HE.input_ (PriorityUp pkgname idxstate priority) ]
                  [ HH.a
@@ -174,8 +175,3 @@ renderTableQueue state num { pkgname, priority, idxstate } =
              ]
   }
 
-showPrio :: Int -> String
-showPrio x
-  | x < 0     = "low"
-  | x == 0    = "medium"
-  | otherwise = "high"

--- a/src-ui/src/Components/PagePackage.purs
+++ b/src-ui/src/Components/PagePackage.purs
@@ -9,69 +9,67 @@ import Halogen.HTML as HH
 import Halogen.HTML.CSS as CSS
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Lib.MatrixApi as Api
-import Lib.MatrixApi2 as Api2
+import Lib.MatrixApi as Api1
+import Lib.MatrixApi2 as Api
 import Lib.Types as T
 import Network.RemoteData as RD
 import Data.Maybe (Maybe(Just, Nothing), fromMaybe)
 import Data.Traversable (Accum, mapAccumL)
 import Lib.MiscFFI as Misc
-import Prelude (type (~>), Unit, bind, const, discard, otherwise, pure, show, ($), (&&), (/=), (<$>), (<>), (==), (>), (||), (>>=), (-), (*), (+))
+import Prelude (type (~>), Unit, bind, negate, const, discard, otherwise, pure, show, (<), (>), ($), (&&), (/=), (<$>), (<>), (==), (||), (>>=), (-), (+), (<<<))
 import DOM.HTML (window) as DOM
 import DOM.HTML.History (DocumentTitle(DocumentTitle), URL(URL), pushState) as DOM
 import DOM.HTML.Window (history) as DOM
 import Debug.Trace
 import Data.Tuple as Tuple
+import Data.Tuple.Nested as TupleN
 import Data.Argonaut as Arg
 import Data.Foreign as F
 import Data.StrMap as SM
-import Data.Either (Either(..))
 import Data.Int as Int
 import Data.Map as Map
+import Data.Ordering (Ordering)
+import Data.Ord (compare)
 
-import Lib.MiscFFI as Misc
 
 type State =
   { initPackage :: Tuple.Tuple T.PackageName T.PackageTS
   , logdisplay  :: D.Display
-  , package     :: T.Package
-  , report      :: RD.RemoteData E.Error T.ShallowReport
+  , report      :: RD.RemoteData E.Error T.PackageIdxTsReports
+  , history     :: Array (Tuple.Tuple T.VersionName T.Revision)
   , highlighted :: Boolean
   , logmessage  :: String
   , columnversion :: T.ColumnVersion
   , newtag :: T.TagName
-  , newPrio :: T.Priority
-  , queueStatus :: RD.RemoteData E.Error (Maybe T.QueueItem)
+  , newPrio :: Int
+  , queueStatus :: RD.RemoteData E.Error T.PackageQueue
   , queueClicked :: Boolean
   , listTimeStamp :: Array T.PkgIdxTs
-  , currentSelectedIdx :: T.PackageTS
+  , currentSelectedIdx :: T.PkgIdxTs
   , latestIndex :: T.PackageTS
   , mapIndexState :: Map.Map Int T.PackageTS
-  , listTags :: Array T.TagName
+  , listTags :: RD.RemoteData E.Error (Array T.TagName)
   , currKey :: Int
   }
 
 data Query a
   = Initialize a
   | FailingPackage a
-  | HighlightCell T.PackageName T.VersionName T.VersionName a
+  | HighlightCell T.PackageIdxTsReports T.CellReportSummary T.VersionName T.VersionName a
   | HandleTag T.TagName a
   | Receive (Tuple.Tuple T.PackageName T.PackageTS) a
   | AddingNewTag T.PackageName T.TagName a
   | RemoveTag T.PackageName T.TagName a
   | UpdateTag (T.PackageName -> a)
   | HandleQueue Int a
-  | QueueBuild T.PackageName T.Priority (RD.RemoteData E.Error (Maybe T.QueueItem)) a
+  | QueueBuild T.PackageName T.PkgIdxTs Int (RD.RemoteData E.Error T.PackageQueue) a
   | HandleIndex State Int a
   | Finalize a
 
 data Message = FromPagePackage
 
-ghcVersions :: Array T.VersionName
-ghcVersions = ["8.2","8.0","7.10","7.8","7.6","7.4"]
-
 component :: forall e.
-             H.Component HH.HTML Query (Tuple.Tuple T.PackageName T.PackageTS) Message (Api.Matrix e)
+             H.Component HH.HTML Query (Tuple.Tuple T.PackageName T.PackageTS) Message (Api1.Matrix e)
 component = H.lifecycleComponent
   { initialState: initialState
   , render
@@ -87,24 +85,22 @@ component = H.lifecycleComponent
       {
         initPackage: i
       , logdisplay: D.displayNone
-      , package: { name: ""
-                 , versions: []
-                 }
       , report: RD.NotAsked
+      , history: []
       , highlighted: false
       , logmessage: ""
       , columnversion: { ghcVer: ""
                        , pkgVer: ""
                        }
       , newtag: ""
-      , newPrio: T.Low
+      , newPrio: 0
       , queueStatus: RD.NotAsked
       , queueClicked: false
       , listTimeStamp: []
-      , currentSelectedIdx: ""
+      , currentSelectedIdx: 0
       , latestIndex: ""
       , mapIndexState: Map.empty
-      , listTags: []
+      , listTags: RD.NotAsked
       , currKey: 0
       }
 
@@ -138,13 +134,13 @@ component = H.lifecycleComponent
                         [ HP.id_ "indexing" ] $
                         renderNavBtn state
                     , HH.div
-                        [ HP.id_ "package" ] [ (renderTableMatrix state.package shallowR) ]
+                        [ HP.id_ "package" ] [ (renderTableMatrix state) ]
                     , HH.h3
                         [ HP.class_ (H.ClassName "logs-header") ]
                         [ HH.text "Logs" ]
                     , HH.div
                         [ HP.id_ "tabs-container" ]
-                        [ (renderLogResult state.logdisplay state.logmessage state.package state.columnversion) ]
+                        [ (renderLogResult state.logdisplay state.logmessage state.report state.columnversion) ]
                     ]
                 ]
             ]
@@ -163,7 +159,7 @@ component = H.lifecycleComponent
                 [ HP.class_ (H.ClassName "leftcol") ]
                 [ HH.h2
                     [ HP.class_ (H.ClassName "main-header") ]
-                    [ HH.text $ _.name state.package ]
+                    [ HH.text $ "" ]
                 ]
             ]
 
@@ -182,7 +178,7 @@ component = H.lifecycleComponent
                 [ HP.class_ (H.ClassName "leftcol") ]
                 [ HH.h2
                     [ HP.class_ (H.ClassName "main-header") ]
-                    [ HH.text $ _.name state.package ]
+                    [ HH.text $ ""]
                 , HH.div
                     [ HP.classes (H.ClassName <$> ["main-header-subtext","error"]) ]
                     [ HH.text $ "This package doesn't have a build report yet. You can request a report by"
@@ -198,13 +194,13 @@ component = H.lifecycleComponent
                         renderNavBtn state
                     , HH.div
                         [ HP.id_ "package" ]
-                        [ (renderTableMatrix state.package { packageName: _.name state.package, modified: "", results: [] }) ]
+                        [ ]
                     , HH.h3
                         [ HP.class_ (H.ClassName "logs-header") ]
                         [ HH.text "Logs" ]
                     , HH.div
                         [ HP.id_ "tabs-container" ]
-                        [ (renderLogResult state.logdisplay state.logmessage state.package state.columnversion) ]
+                        [ ]
                     ]
                 ]
             ]
@@ -262,51 +258,58 @@ component = H.lifecycleComponent
                 if Arr.null st.listTimeStamp then timeStampIsEmpty else generateIndexStateButton st
             ]
 
-    eval :: Query ~> H.ComponentDSL State Query Message (Api.Matrix e)
+    eval :: Query ~> H.ComponentDSL State Query Message (Api1.Matrix e)
     eval (Initialize next) = do
       st <- H.get
-      listIndex <- Api2.getPackageReports  (Tuple.fst st.initPackage)
-      tags <- Api2.getPackageTags (Tuple.fst st.initPackage)
+      listIndex <- Api.getPackageReports  (Tuple.fst st.initPackage)
+      tags <- Api.getPackageTags (Tuple.fst st.initPackage)
+      historyPackage <- H.lift $ Api.getPackageHistories (Tuple.fst st.initPackage)
       let
         listIndex' =
           case listIndex of
             RD.Success idx' -> idx'
             _               -> []
         latestIdx = Misc.getLastIdx listIndex'
+        selectedIdx = getIdx (Tuple.snd st.initPackage) listIndex'
         mapIdxSt = Map.fromFoldable (toTupleArray listIndex)
         maxKey =
           case Map.findMax mapIdxSt of
             Just { key } -> (key :: Int)
             Nothing      -> 0
-      packageByName <- H.lift $ Api.getPackageByName (Tuple.fst st.initPackage)
-      reportPackage <- H.lift $
-        if Str.null (Tuple.snd st.initPackage)
-        then Api.getLatestReportByPackageName (Tuple.fst st.initPackage)
-        else (Api.getLatestReportByPackageTimestamp (Tuple.fst st.initPackage) (Tuple.snd st.initPackage))
-                >>= Api2.parseShallowReport
-      queueStat <- H.lift $ Api.getQueueByName (Tuple.fst st.initPackage)
-      H.modify _  { package = packageByName
-                  , report = reportPackage
+        hist = case historyPackage of
+          RD.Success hs -> Arr.sortBy sortVer (Arr.zip (TupleN.get2 <$> hs) (TupleN.get3 <$> hs))
+          _             -> []
+      reportPackage <- H.lift $ Api.getPackageIdxTsReports (Tuple.fst st.initPackage) selectedIdx
+      queueStat <- H.lift $ Api.getSpecificQueue (Tuple.fst st.initPackage) selectedIdx
+      H.modify _  { report = reportPackage
+                  , history = hist
                   , highlighted = false
                   , queueStatus = queueStat
                   , listTimeStamp = listIndex'
-                  , currentSelectedIdx = Tuple.snd st.initPackage
-                  , latestIndex = latestIdx
+                  , currentSelectedIdx = selectedIdx
+                  , latestIndex = show latestIdx
                   , mapIndexState = mapIdxSt
-                  , listTags =
-                      case tags of
-                        (RD.Success a) -> a
-                        _              -> []
+                  , listTags = tags
                   , currKey = maxKey
                   }
       pure next
     eval (FailingPackage next) = do
       pure next
-    eval (HighlightCell pkgName ghcVer pkgVer next) = do
-      singleResult <- H.lift $ Api.getSingleResult pkgName (ghcVer <> "-" <> pkgVer)
-      H.modify _ { logmessage = (if ( isContainedLog singleResult.resultA )
-                                 then ""
-                                 else pickLogMessage singleResult )
+    eval (HighlightCell {pkgname, idxstate} summ ghcVer pkgVer next) = do
+      singleResult <- H.lift $ Api.getCellReportDetail pkgname idxstate pkgVer ghcVer
+      let
+        sRU = case singleResult of
+               RD.Success a -> a.units
+               _            -> []
+        sRS = case singleResult of
+               RD.Success a -> a.solverE
+               _            -> ""
+        arrKeys = Arr.concat (SM.keys <$> sRU)
+        logs = case summ.crsT of
+          "pf" -> sRS
+          "se" -> ""
+          _    -> ""
+      H.modify _ { logmessage = logs
                  , logdisplay = D.block
                  , columnversion = { ghcVer, pkgVer }
                  }
@@ -316,11 +319,11 @@ component = H.lifecycleComponent
       H.put $ st { newtag = value }
       pure next
     eval (AddingNewTag newTag pkgName next) = do
-      _ <- H.lift $ Api2.putPackageTag newTag pkgName
+      _ <- H.lift $ Api.putPackageTag newTag pkgName
       H.raise $ FromPagePackage
       pure next
     eval (RemoveTag tagName pkgName next) = do
-      _ <- H.lift $ Api2.deletePackageTag tagName pkgName
+      _ <- H.lift $ Api.deletePackageTag tagName pkgName
       H.raise $ FromPagePackage
       pure next
     eval (UpdateTag reply) = do
@@ -329,57 +332,55 @@ component = H.lifecycleComponent
       reply <$> (pure packageName)
     eval (Receive pkg next) = do
       st <- H.get
-      listIndex <- Api2.getPackageReports (Tuple.fst pkg)
-      tags <- Api2.getPackageTags (Tuple.fst pkg)
+      listIndex <- Api.getPackageReports (Tuple.fst pkg)
+      tags <- Api.getPackageTags (Tuple.fst pkg)
+      historyPackage <- H.lift $ Api.getPackageHistories (Tuple.fst pkg)
       let
         listIndex' =
           case listIndex of
             RD.Success idx' -> idx'
             _              -> []
         latestIdx = Misc.getLastIdx listIndex'
+        selectedIdx = getIdx (Tuple.snd pkg) listIndex'
         mapIdxSt = Map.fromFoldable (toTupleArray listIndex)
         maxKey =
           case Map.findMax mapIdxSt of
             Just { key } -> (key :: Int)
             Nothing      -> 0
-      packageByName <- H.lift $ Api.getPackageByName (Tuple.fst pkg)
-      reportPackage <- H.lift $
-        if Str.null (Tuple.snd pkg)
-        then  Api.getLatestReportByPackageName (Tuple.fst pkg)
-        else  (Api.getLatestReportByPackageTimestamp (Tuple.fst pkg) (Tuple.snd pkg))
-                 >>= Api2.parseShallowReport
-      queueStat <- H.lift $ Api.getQueueByName (Tuple.fst pkg)
-      H.modify _ { initPackage = pkg
-                 , package = packageByName
-                 , report = reportPackage
-                 , queueStatus = queueStat
-                 , listTimeStamp = listIndex'
-                 , latestIndex = latestIdx
-                 , currentSelectedIdx = Tuple.snd pkg
-                 , mapIndexState = mapIdxSt
-                 , listTags =
-                      case tags of
-                        (RD.Success a) -> a
-                        _              -> []
-                 , currKey =
+        hist = case historyPackage of
+          RD.Success hs -> Arr.sortBy sortVer $ Arr.zip (TupleN.get2 <$> hs) (TupleN.get3 <$> hs)
+          _             -> []
+      reportPackage <- H.lift $ Api.getPackageIdxTsReports (Tuple.fst pkg) selectedIdx
+      queueStat <- H.lift $ Api.getSpecificQueue (Tuple.fst st.initPackage) selectedIdx
+      H.modify _  { report = reportPackage
+                  , history = hist
+                  , highlighted = false
+                  , queueStatus = queueStat
+                  , listTimeStamp = listIndex'
+                  , currentSelectedIdx = selectedIdx
+                  , latestIndex = show latestIdx
+                  , mapIndexState = mapIdxSt
+                  , listTags = tags
+                  , currKey =
                       case Arr.elemIndex (Tuple.snd pkg) (show <$> listIndex') of
                         Just a  -> a
                         Nothing -> maxKey
-                 }
+                  }
       pure next
     eval (HandleQueue idx next) = do
+      st <- H.get
       _ <- case idx of
-              1 -> H.modify _ { newPrio = T.Medium}
-              2 -> H.modify _ { newPrio = T.Low}
-              _ -> H.modify _ { newPrio = T.High}
+              1 -> H.modify _ { newPrio = 0}
+              2 -> H.modify _ { newPrio = (negate 10)}
+              _ -> H.modify _ { newPrio = 10}
       pure next
-    eval (QueueBuild pkgName prio (RD.Success _) next ) = do
-      _ <- H.lift $ Api.putQueueSaveByName pkgName prio
+    eval (QueueBuild pkgName currIdx prio (RD.Success queue) next ) = do
+      _ <- H.lift $ Api.putPackageQueue pkgName queue.idxstate prio
       H.modify _ { queueClicked = true }
       pure next
-    eval (QueueBuild pkgName prio _ next) = do
+    eval (QueueBuild pkgName currIdx prio _ next) = do
       H.modify _ { queueClicked = true }
-      _ <- H.lift $ Api.putQueueCreate pkgName prio
+      _ <- H.lift $  Api.putPackageQueue pkgName currIdx prio
       pure next
     eval (HandleIndex st idx next) = do
       -- traceAnyA ("current index is : " <> (show idx))
@@ -402,12 +403,12 @@ component = H.lifecycleComponent
     eval (Finalize next) = do
       pure next
 
-checkQueueStatus :: forall p i. RD.RemoteData E.Error (Maybe T.QueueItem) ->  Array (HH.HTML p i)
-checkQueueStatus (RD.Success (Just qi)) =
+checkQueueStatus :: forall p i. RD.RemoteData E.Error T.PackageQueue ->  Array (HH.HTML p i)
+checkQueueStatus (RD.Success qi) =
   [ HH.div
       [ HP.class_ (H.ClassName "already-queued") ]
       [ HH.text ("This package is already in " <>
-                 qi.priority <>
+                 Misc.showPrio qi.priority <>
                  " priority queue. You can change its priority queue below.")
       ]
   ]
@@ -431,19 +432,19 @@ generateQueueButton st =
                 , HE.onSelectedIndexChange $ HE.input HandleQueue
                 ] $
                 [ HH.option
-                    ([ HP.value "high" ] <> isPrioSelected "high" st.queueStatus)
+                    ([ HP.value "high" ] <> isPrioSelected 10 st.queueStatus)
                     [ HH.text "High" ]
                 , HH.option
-                    ([ HP.value "medium" ] <> isPrioSelected "medium" st.queueStatus)
+                    ([ HP.value "medium" ] <> isPrioSelected 0 st.queueStatus)
                     [ HH.text "Medium" ]
                 , HH.option
-                    ([ HP.value "low" ] <> isPrioSelected "low" st.queueStatus)
+                    ([ HP.value "low" ] <> isPrioSelected (negate 10) st.queueStatus)
                     [ HH.text "Low" ]
                 ]
             ]
         , HH.button
             [ HP.class_ (H.ClassName "action")
-            , HE.onClick $ HE.input_ (QueueBuild (Tuple.fst st.initPackage) st.newPrio st.queueStatus)
+            , HE.onClick $ HE.input_ (QueueBuild (Tuple.fst st.initPackage) st.currentSelectedIdx st.newPrio st.queueStatus)
             ]
             [ HH.text "Queue build for this package" ]
         ]
@@ -470,16 +471,16 @@ isIndexSelected :: forall p i. State
                 -> T.PackageTS
                 -> Array (HH.IProp (selected :: Boolean | p) i)
 isIndexSelected st idx =
-  case st.currentSelectedIdx == idx of
+  case (show st.currentSelectedIdx) == idx of
     true  -> [HP.selected true]
-    false -> if Str.null st.currentSelectedIdx && st.latestIndex == idx
+    false -> if Str.null (show st.currentSelectedIdx) && st.latestIndex == idx
                 then [HP.selected true]
                 else []
 
-isPrioSelected :: forall p i. String
-               -> RD.RemoteData E.Error (Maybe T.QueueItem)
+isPrioSelected :: forall p i. Int
+               -> RD.RemoteData E.Error T.PackageQueue
                -> Array (HH.IProp (selected :: Boolean | p) i)
-isPrioSelected prio (RD.Success (Just qi)) =
+isPrioSelected prio (RD.Success qi) =
   case prio == qi.priority of
     true -> [HP.selected true]
     false -> []
@@ -497,8 +498,8 @@ renderMissingPackage pkgName =
         [ HH.text "leaving a comment here"]
     ]
 
-renderLogResult :: forall p i. D.Display -> String -> T.Package -> T.ColumnVersion -> HH.HTML p i
-renderLogResult logdisplay log { name } { ghcVer, pkgVer } =
+renderLogResult :: forall p i. D.Display -> String -> RD.RemoteData E.Error T.PackageIdxTsReports -> T.ColumnVersion -> HH.HTML p i
+renderLogResult logdisplay log (RD.Success ({ pkgname })) { ghcVer, pkgVer } =
   HH.div
     [ HP.id_ "tabs"
     , HP.classes (H.ClassName <$> ["ui-tabs","ui-widget","ui-widget-content","ui-corner-all"])
@@ -516,7 +517,7 @@ renderLogResult logdisplay log { name } { ghcVer, pkgVer } =
                 [ HP.class_ (H.ClassName "ui-tabs-anchor")
                 , HP.attr (H.AttrName "role") "presentation"
                 ]
-                [ HH.text $ cellHash ghcVer name pkgVer ]
+                [ HH.text $ cellHash ghcVer pkgname pkgVer ]
             ]
         ]
     , HH.div
@@ -529,12 +530,13 @@ renderLogResult logdisplay log { name } { ghcVer, pkgVer } =
             [ HH.text log ]
         ]
     ]
+renderLogResult _ _ _ _ = HH.div_ []
 
 renderPackageTag ::  forall p. T.PackageName
-                 -> Array T.TagName
+                 -> RD.RemoteData E.Error (Array T.TagName)
                  -> T.TagName
                  -> Array (HH.HTML p (Query Unit))
-renderPackageTag pkgName tags newtag =
+renderPackageTag pkgName (RD.Success tags) newtag =
   (\x -> HH.li_
            [ HH.span_ [HH.text $ x]
            , HH.a
@@ -544,6 +546,7 @@ renderPackageTag pkgName tags newtag =
                [HH.text "╳"]
            ]
   ) <$> tags
+renderPackageTag pkgName _ _ = []
 
 generateIndexStateButton :: forall p. State -> Array (HH.HTML p (Query Unit))
 generateIndexStateButton st =
@@ -566,68 +569,99 @@ timeStampIsEmpty =
       [ HH.text "Index State is empty." ]
   ]
 
-pickLogMessage :: T.SingleResult -> String
-pickLogMessage { resultA } = logMessage resultA
-
-logMessage :: Maybe T.VersionResult -> String
-logMessage (Just { result }) =
-  case result of
-    (T.Fail str) -> str
-    _          -> " "
-logMessage  _  = " "
-
-isContainedLog :: Maybe T.VersionResult -> Boolean
-isContainedLog versionR = Str.null $ logMessage versionR
-
-renderTableMatrix :: forall p. T.Package
-                  -> T.ShallowReport
+renderTableMatrix :: forall p. State
                   -> HH.HTML p (Query Unit)
-renderTableMatrix package shallowR =
+renderTableMatrix {report: RD.Success (pkgreport), history} =
   HH.table_
     [ HH.thead_
         [ HH.tr_ $
             [ HH.th_
                 [ HH.a
-                    [ HP.href $ "https://hackage.haskell.org/package/" <> package.name ]
-                    [ HH.text package.name ]
+                    [ HP.href $ "https://hackage.haskell.org/package/" <> pkgreport.pkgname ]
+                    [ HH.text pkgreport.pkgname ]
                 ]
-            ] <> ((\x -> HH.th_ $ [HH.text x]) <$> ghcVersions)
+            ] <> ((\x -> HH.th_ $ [HH.text (ghcVersions x)]) <$> pkgreport.hcversions)
         ]
     , HH.tbody_ $ Arr.reverse $ getTheResult accumResult
     ]
   where
-    accumResult = mapAccumL (generateTableRow package shallowR)
-                            ({version: "0", revision: 0, preference: T.Normal})
-                            package.versions
+    accumResult = mapAccumL (generateTableRow pkgreport)
+                            (Tuple.Tuple "" 0)
+                            history
     getTheResult { value } = value
+    ghcVersions x =
+      case Str.stripPrefix (Str.Pattern "ghc-") x of
+        Just a -> a
+        Nothing -> "Failed"
+renderTableMatrix _ =
+  HH.table_
+    [ HH.thead_
+        [ HH.tr_ $
+            [ HH.th_
+                [ HH.a
+                    [ HP.href $ "https://hackage.haskell.org/package/" ]
+                    [ HH.text "" ]
+                ]
+            ]
+        ]
+    , HH.tbody_ []
+    ]
 
-generateTableRow :: forall p. T.Package
-                 -> T.ShallowReport
-                 -> T.VersionInfo
-                 -> T.VersionInfo
-                 -> Accum T.VersionInfo (HH.HTML p (Query Unit))
-generateTableRow package shallowR prevVer currentVer  =
+generateTableRow :: forall p. T.PackageIdxTsReports
+                 -> Tuple.Tuple T.VersionName T.Revision
+                 -> Tuple.Tuple T.VersionName T.Revision
+                 -> Accum (Tuple.Tuple T.VersionName T.Revision) (HH.HTML p (Query Unit))
+generateTableRow pkgreport prevVer currentVer  =
   { accum: const currentVer prevVer
-  , value: HH.tr
-             [ HP.classes (H.ClassName <$> (["solver-row"] <> packageVersioning (minorCheck prevVer currentVer)
-                                                                                (majorCheck prevVer currentVer))) ] $
+  , value:
+      if Arr.null ghcResult
+         then
+          HH.tr
+             [ HP.classes (H.ClassName <$> (["solver-row"] <> packageVersioning (minorCheck pv cv)
+                                                                                (majorCheck pv cv))) ] $
              [ HH.th
                  [ HP.class_ (H.ClassName "pkgv") ] $
                  [ HH.a
-                     [ HP.href $ hdiffUrl package.name prevVer currentVer
+                     [ HP.href $ hdiffUrl pkgreport.pkgname pv cv
                      ]
                      [ HH.text "Δ" ]
                  , HH.a
-                     [ HP.href $ hackageUrl package.name currentVer.version ]
-                     [ HH.text currentVer.version ]
-                 ] <> (if currentVer.revision > 0
-                       then [ (containedRevision package.name currentVer.version currentVer.revision) ]
+                     [ HP.href $ hackageUrl pkgreport.pkgname cv ]
+                     [ HH.text cv ]
+                 ] <> (if Tuple.snd currentVer > 0
+                       then [ (containedRevision pkgreport.pkgname cv (Tuple.snd currentVer)) ]
                        else [])
-             ] <> Arr.reverse (generateTableColumn package shallowR.results currentVer.version <$> (Arr.reverse ghcVersions))
+             ] <> Arr.reverse (generateTableColumn pkgreport cv ghcResult <$> (Arr.reverse buildEmpty))
+         else
+          HH.tr
+             [ HP.classes (H.ClassName <$> (["solver-row"] <> packageVersioning (minorCheck pv cv)
+                                                                                (majorCheck pv cv))) ] $
+             [ HH.th
+                 [ HP.class_ (H.ClassName "pkgv") ] $
+                 [ HH.a
+                     [ HP.href $ hdiffUrl pkgreport.pkgname pv cv
+                     ]
+                     [ HH.text "Δ" ]
+                 , HH.a
+                     [ HP.href $ hackageUrl pkgreport.pkgname cv ]
+                     [ HH.text cv ]
+                 ] <> (if Tuple.snd currentVer > 0
+                       then [ (containedRevision pkgreport.pkgname cv (Tuple.snd currentVer)) ]
+                       else [])
+             ] <> Arr.reverse (generateTableColumn pkgreport cv ghcResult <$> (Arr.reverse buildReport))
   }
   where
-    splitPrevVer prev = if prev.version == "0" then [""] else splitVersion prev.version
-    splitCurrVer curr = splitVersion curr.version
+    ghcResult =
+      case SM.lookup cv pkgreport.pkgversions of
+        Just arr -> arr
+        Nothing  -> []
+    cv = Tuple.fst currentVer
+    pv = Tuple.fst prevVer
+    buildReport = Arr.zip pkgreport.hcversions ghcResult
+    buildEmpty = (\x -> Tuple.Tuple x reportDefault) <$> pkgreport.hcversions
+    reportDefault = {crsT: "na", crsBjle: 0, crsPerr: false, crsBok: 0, crsBfail: 0, crsBdfail: 0}
+    splitPrevVer prev = if prev == "0" then [""] else splitVersion prev
+    splitCurrVer curr = splitVersion curr
     majorCheck prev curr = newMajor (splitPrevVer prev) (splitCurrVer curr)
     minorCheck prev curr = newMinor (splitPrevVer prev) (splitCurrVer curr)
 
@@ -655,46 +689,38 @@ packageVersioning minor major
   | minor          = ["first-minor"]
   | otherwise      = []
 
-generateTableColumn :: forall p. T.Package
-                    -> Array T.ShallowGhcResult
+generateTableColumn :: forall p. T.PackageIdxTsReports
                     -> T.VersionName
-                    -> T.VersionName
+                    -> Array T.CellReportSummary
+                    -> Tuple.Tuple T.HCVer T.CellReportSummary
                     -> HH.HTML p (Query Unit)
-generateTableColumn package shallowGhcArr verName ghcVer =
-  case isContainedVersion ghcVer verName shallowGhcArr && isContainedGHC ghcVer shallowGhcArr of
-    true -> renderContained
-    false -> renderNotContained
+generateTableColumn package verName ghcRes (Tuple.Tuple ghcVer summ) =
+  if Arr.null ghcRes then renderNotContained
+  else
+    case summ.crsT of
+      "na" -> renderNotContained
+      _    -> renderContained
   where
     renderContained =
-      HH.td
-        [ HP.classes $ H.ClassName <$>
-                        (["stcell"] <>
-                         (Arr.concat $ checkPassOrFail verName <$>
-                          (getShallowVer ghcVer shallowGhcArr)))
-        , HP.attr (H.AttrName "data-ghc-version") ghcVer
-        , HP.attr (H.AttrName "data-package-version") verName
-        , HE.onClick $ HE.input_ (HighlightCell package.name ghcVer verName)
-        ] $ [ HH.text (Str.joinWith "" $ checkShallow verName <$>
-                                         (getShallowVer ghcVer shallowGhcArr)) ]
+        HH.td
+          [ HP.classes $ H.ClassName <$>
+                          (["stcell"] <>
+                           (checkPassOrFail summ))
+          , HP.attr (H.AttrName "data-ghc-version") ghcVer
+          , HP.attr (H.AttrName "data-package-version") verName
+          , HE.onClick $ HE.input_ (HighlightCell package summ ghcVer verName)
+          ] $ [ HH.text (checkShallow summ) ]
     renderNotContained =
-      HH.td
-        [ HP.classes (H.ClassName <$> (["stcell", "fail-unknown"]))
-        , HP.attr (H.AttrName "data-ghc-version") ghcVer
-        , HP.attr (H.AttrName "data-package-version") verName
-        , HE.onClick $ HE.input_ (HighlightCell package.name ghcVer verName)
-        ] $ [ HH.text ""]
-
-getShallowVer :: T.VersionName -> Array T.ShallowGhcResult -> Array T.ShallowVersionResult
-getShallowVer ghcVer ghcArr =
-  case Arr.uncons filteredArr of
-    Just { head: x, tail: xs } -> x.ghcResult
-    Nothing                    -> []
-  where
-    filteredArr = Arr.filter (\x -> x.ghcVersion == ghcVer) ghcArr
+        HH.td
+          [ HP.classes (H.ClassName <$> (["stcell", "fail-unknown"]))
+          , HP.attr (H.AttrName "data-ghc-version") ghcVer
+          , HP.attr (H.AttrName "data-package-version") verName
+          , HE.onClick $ HE.input_ (HighlightCell package summ ghcVer verName)
+          ] $ [ HH.text ""]
 
 containedRevision :: forall p i. T.PackageName
                   -> T.VersionName
-                  -> T.Word
+                  -> T.Revision
                   -> HH.HTML p i
 containedRevision pkgName verName revision =
     HH.sup_
@@ -718,48 +744,43 @@ isContainedVersion ghcVer verName shallowGhcArr =
     (Just { ghcResult }) -> Arr.elem verName (_.packageVersion <$> ghcResult)
     Nothing              -> false
 
-checkPassOrFail :: T.VersionName -> T.ShallowVersionResult -> Array String
-checkPassOrFail verName { packageVersion, result }
-  | verName == packageVersion = passOrFail result
-  | otherwise                 = []
+checkPassOrFail :: T.CellReportSummary -> Array String
+checkPassOrFail summ =
+  case summ.crsT of
+    "pf" -> ["pass-no-ip"]
+    "se" -> getBuild summ
+    _    -> ["fail-unknown"]
+  where
+    getBuild summ
+      | summ.crsBjle == 1 = ["fail-bj"]
+      | summ.crsBok == 1 = ["pass-build"]
+      | summ.crsBfail == 1 = ["fail-build"]
+      | summ.crsBdfail == 1 = ["fail-dep-build"]
+      | otherwise = ["fail-unknown"]
 
-passOrFail :: T.ShallowResult -> Array String
-passOrFail sR =
-  case sR of
-    T.ShallowOk            -> ["pass-build"]
-    T.ShallowNop           -> ["pass-no-op"]
-    T.ShallowNoIp          -> ["pass-no-ip"]
-    T.ShallowNoIpBjLimit _ -> ["fail-bj"]
-    T.ShallowNoIpFail      -> ["fail-no-ip"]
-    T.ShallowFail          -> ["fail-build"]
-    T.ShallowFailDeps _    -> ["fail-dep-build"]
-    T.Unknown              -> ["fail-unknown"]
 
-checkShallow :: T.VersionName -> T.ShallowVersionResult -> String
-checkShallow verName { packageVersion, result }
-  | verName == packageVersion = checkShallowResult result
-  | otherwise                 = ""
+checkShallow :: T.CellReportSummary -> String
+checkShallow summ =
+  case summ.crsT of
+    "pf" -> "OK (no-ip)"
+    "se" -> getBuild summ
+    _    -> ""
+  where
+    getBuild summ
+      | summ.crsBjle == 1 = "FAIL (BJ)"
+      | summ.crsBok == 1 = "OK"
+      | summ.crsBfail == 1 = "FAIL (pkg)"
+      | summ.crsBdfail == 1 = "FAIL (deps)" 
+      | otherwise = ""
 
-checkShallowResult :: T.ShallowResult -> String
-checkShallowResult sR =
-  case sR of
-    T.ShallowOk            -> "OK"
-    T.ShallowNop           -> "OK (boot)"
-    T.ShallowNoIp          -> "OK (no-ip)"
-    T.ShallowNoIpBjLimit _ -> "FAIL (BJ)"
-    T.ShallowNoIpFail      -> "FAIL (no-ip)"
-    T.ShallowFail          -> "FAIL (pkg)"
-    T.ShallowFailDeps _    -> "FAIL (deps)"
-    T.Unknown              -> ""
-
-hdiffUrl :: T.PackageName -> T.VersionInfo -> T.VersionInfo -> T.HdiffUrl
+hdiffUrl :: T.PackageName -> T.HCVer -> T.HCVer -> T.HdiffUrl
 hdiffUrl pkgName prevVer currVer
-  | prevVer.version == "0"             = "http://hdiff.luite.com/cgit/" <> pkgName <> "/commit?id=" <> currVer.version
-  | currVer.version == prevVer.version = "http://hdiff.luite.com/cgit/" <> pkgName <> "/diff?id=" <> currVer.version
+  | prevVer == "0"             = "http://hdiff.luite.com/cgit/" <> pkgName <> "/commit?id=" <> currVer
+  | currVer == prevVer         = "http://hdiff.luite.com/cgit/" <> pkgName <> "/diff?id=" <> currVer
   | otherwise = "http://hdiff.luite.com/cgit/" <>
                                          pkgName <> "/diff?id=" <>
-                                         currVer.version <> "&id2="
-                                         <> prevVer.version
+                                         currVer <> "&id2="
+                                         <> prevVer
 
 hackageUrl :: T.PackageName -> T.VersionName -> T.HackageUrl
 hackageUrl pkgName versionName =
@@ -772,7 +793,16 @@ revisionsUrl pkgName versionName =
 
 cellHash :: T.VersionName -> T.PackageName -> T.VersionName -> T.Cell
 cellHash ghcVer pkgName pkgVer =
-  "GHC-" <> ghcVer <> "/" <> pkgName <> "-" <> pkgVer
+  Str.toUpper ghcVer <> "/" <> pkgName <> "-" <> pkgVer
+
+getIdx :: T.PackageTS -> Array T.PkgIdxTs -> T.PkgIdxTs
+getIdx idx listIdx =
+  if Str.null idx
+  then Misc.getLastIdx listIdx
+  else
+    case (Arr.head <<< (Arr.takeWhile (\x -> idx == show x))) listIdx of
+      Just a -> a
+      Nothing -> 0
 
 renderNavBtn :: forall p. State -> Array (HH.HTML p (Query Unit))
 renderNavBtn st =
@@ -896,3 +926,12 @@ legend =
             ]
             [ HH.text "Refresh listings" ]
         ]
+
+sortVer :: Tuple.Tuple T.VersionName T.Revision -> Tuple.Tuple T.VersionName T.Revision -> Ordering
+sortVer (Tuple.Tuple ver1 _) (Tuple.Tuple ver2 _) =
+  let
+    v1 = ((fromMaybe 9) <<< Int.fromString) <$> Str.split (Str.Pattern ".") ver1
+    v2 = ((fromMaybe 0) <<< Int.fromString) <$> Str.split (Str.Pattern ".") ver2
+  in
+   compare v1 v2
+

--- a/src-ui/src/Components/PagePackage.purs
+++ b/src-ui/src/Components/PagePackage.purs
@@ -370,7 +370,8 @@ component = H.lifecycleComponent
           _             -> []
       reportPackage <- H.lift $ Api.getPackageIdxTsReports (Tuple.fst pkg) selectedIdx
       queueStat <- H.lift $ Api.getSpecificQueue (Tuple.fst st.initPackage) selectedIdx
-      H.modify _  { report = reportPackage
+      H.modify _  { initPackage = pkg
+                  , report = reportPackage
                   , history = hist
                   , highlighted = false
                   , queueStatus = queueStat
@@ -832,8 +833,10 @@ getIdx idx listIdx =
 renderUnitsButton :: forall p. State -> Array (SM.StrMap T.BuildStatus) -> T.ColumnVersion -> Array (HH.HTML p (Query Unit))
 renderUnitsButton st arrUnit {ghcVer, pkgVer} =
   let
+    keys = Arr.concat (SM.keys <$> arrUnit)
+    values = Arr.concat (SM.values <$> arrUnit)
     buttonRef :: Array (Tuple.Tuple String T.BuildStatus)
-    buttonRef = Arr.concat (SM.toUnfoldable <$> arrUnit)
+    buttonRef = Arr.zip keys values
   in
     [
       HH.div
@@ -854,6 +857,8 @@ renderButton ghcVer pkgVer (Tuple.Tuple units status) =
       , HE.onClick $ HE.input_ (HighlightSE (Tuple.Tuple units status))
       ]
       [ HH.text (buildText status) ]
+
+
 
 renderNavBtn :: forall p. State -> Array (HH.HTML p (Query Unit))
 renderNavBtn st =

--- a/src-ui/src/Components/PagePackage.purs
+++ b/src-ui/src/Components/PagePackage.purs
@@ -23,6 +23,7 @@ import DOM.HTML.Window (history) as DOM
 import Debug.Trace
 import Data.Tuple as Tuple
 import Data.Tuple.Nested as TupleN
+import Data.Foldable as Foldable
 import Data.Argonaut as Arg
 import Data.Foreign as F
 import Data.StrMap as SM
@@ -281,6 +282,8 @@ component = H.lifecycleComponent
           _             -> []
       reportPackage <- H.lift $ Api.getPackageIdxTsReports (Tuple.fst st.initPackage) selectedIdx
       queueStat <- H.lift $ Api.getSpecificQueue (Tuple.fst st.initPackage) selectedIdx
+      traceAnyA listIndex'
+      traceAnyA selectedIdx
       H.modify _  { report = reportPackage
                   , history = hist
                   , highlighted = false
@@ -383,7 +386,7 @@ component = H.lifecycleComponent
       _ <- H.lift $  Api.putPackageQueue pkgName currIdx prio
       pure next
     eval (HandleIndex st idx next) = do
-      -- traceAnyA ("current index is : " <> (show idx))
+      traceAnyA ("current index is : " <> (show idx))
       H.modify _ { currKey = idx }
       let
         selectedIndex' =
@@ -800,7 +803,7 @@ getIdx idx listIdx =
   if Str.null idx
   then Misc.getLastIdx listIdx
   else
-    case (Arr.head <<< (Arr.takeWhile (\x -> idx == show x))) listIdx of
+    case Foldable.find (\x -> idx == show x) listIdx of
       Just a -> a
       Nothing -> 0
 

--- a/src-ui/src/Components/PagePackages.purs
+++ b/src-ui/src/Components/PagePackages.purs
@@ -120,25 +120,17 @@ component = H.lifecycleComponent
     listPkg <- liftEff $ Ref.readRef pkgRef
     tagList <- H.lift Api2.getTagsWithoutPackage
     tagPkgList <- H.lift Api2.getTagsWithPackages
-    traceAnyA "after get tags withPkg api calls"
     lastIdx <- H.lift Api2.getPackagesIdxstate
-    traceAnyA "after pkg idx calls"
     let
       pkgTag = case tagPkgList of
         RD.Success a -> a
         _ -> SM.empty
       tagPkgs = pkgTagList pkgTag
-    traceAnyA "before get lastpkgIdx"
-    traceAnyA "after parse lastpkgidx"
-    traceAnyA "after parse pkgArr"
     H.modify  _ { packages = listPkg
                 , tags = tagList
                 , tagsMap = tagPkgs
                 , latestIdxState = lastIdx
                 }
-    traceAnyA "update state latestIdxState"
-    traceAnyA "update State"
-    -- traceAnyA tagPkgList
     pure next
 
   eval (SelectedTag tag next) = do

--- a/src-ui/src/Container.purs
+++ b/src-ui/src/Container.purs
@@ -192,7 +192,7 @@ ui =
       pure next
 
     eval (HandleKeyboard key next) = do
-      _ <- traceAnyA (DOM.key key)
+      -- _ <- traceAnyA (DOM.key key)
       let
         str = DOM.key key
       case str of

--- a/src-ui/src/Lib/Matrix.purs
+++ b/src-ui/src/Lib/Matrix.purs
@@ -37,11 +37,11 @@ type Environment e =
   }
 
 
-type MatrixApi' eff = ReaderT (Environment eff) (Aff (HalogenEffects (api :: API, ajax :: Affjax.AJAX  , dom :: DOM, history :: DOM.HISTORY| eff)))
+type MatrixApi' eff = ReaderT (Environment eff) (Aff (HalogenEffects (api :: API, ajax :: Affjax.AJAX  , dom :: DOM, history :: DOM.HISTORY, window :: DOM.WINDOW| eff)))
 
 type Matrix eff = MatrixApi' eff
 
-type MatrixEffects = HalogenEffects (api :: API, ajax :: Affjax.AJAX, dom :: DOM, history :: DOM.HISTORY)
+type MatrixEffects = HalogenEffects (api :: API, ajax :: Affjax.AJAX, dom :: DOM, history :: DOM.HISTORY, window :: DOM.WINDOW)
 
 foreign import newApi :: forall eff
    . String

--- a/src-ui/src/Lib/Matrix2.purs
+++ b/src-ui/src/Lib/Matrix2.purs
@@ -276,7 +276,6 @@ getTagsWithPackages = do
     SC.StatusCode 200 -> do
       let
         decodedApi = Arg.decodeJson (res.response) -- :: SM.StrMap (Array String))
-      --MP.toTagsWithPackages decodedApi
       case decodedApi of
         Right a -> pure $ RD.Success a
         Left e  -> pure $ RD.Failure (E.error "decoding failed")
@@ -375,7 +374,7 @@ getQueuePackages pkgName = do
 getSpecificQueue :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
                => T.PackageName
                -> T.PkgIdxTs
-               -> m (RD.RemoteData E.Error (Array T.PackageQueue))
+               -> m (RD.RemoteData E.Error T.PackageQueue)
 getSpecificQueue pkgName idx = do
   res <- liftAff (Affjax.affjax Affjax.defaultRequest
                         {
@@ -386,7 +385,7 @@ getSpecificQueue pkgName idx = do
     SC.StatusCode 200 -> do
       let
         decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-      MP.toPackageQueue decodedApi
+      MP.toSpecificPackageQueue decodedApi
     SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/queue/{pkgname}/{idxstate}

--- a/src-ui/src/Lib/Matrix2.purs
+++ b/src-ui/src/Lib/Matrix2.purs
@@ -57,8 +57,10 @@ getIdxstate = do
   case res.status of
     SC.StatusCode 200 -> do
       let
-        decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-      MP.parseJsonToArrayTS decodedApi
+        decodedApi = Arg.decodeJson res.response
+      case decodedApi of
+        Right a -> pure (RD.Success a)
+        Left e  -> pure (RD.Failure (E.error "decoded failed"))
     SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/idxstates/latest
@@ -128,7 +130,9 @@ getPackageTags pkgName = do
         (SC.StatusCode 200)  -> do
           let
             decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-          MP.parseJsonToArrayS decodedApi
+          case decodedApi of
+            Right a -> pure (RD.Success a)
+            Left e  -> pure (RD.Failure (E.error "decoded failed"))
         SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/packages/*/reports/latest
@@ -142,10 +146,8 @@ getPackagesIdxstate = do
                         })
   case res.status of
     SC.StatusCode 200 -> do
-      _ <- traceAnyA "before decoded"
       let
         decodedApi = Arg.foldJsonObject SM.empty unsafeCoerce res.response --Arg.decodeJson (res.response)
-      _ <- traceAnyA "after decoded"
       if SM.isEmpty decodedApi then pure $ RD.Failure (E.error "decoding failed") else pure $ RD.Success decodedApi
     SC.StatusCode 304 -> do
       let
@@ -171,7 +173,9 @@ getPackageReports pkgName =
          SC.StatusCode 200 -> do
            let
              decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-           MP.parseJsonToArrayTS decodedApi
+           case decodedApi of
+             Right a -> pure (RD.Success a)
+             Left e  -> pure (RD.Failure (E.error "decoded failed"))
          SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/packages/{pkgname}/reports/{idxstate}
@@ -297,11 +301,15 @@ getTagsWithoutPackage = do
     SC.StatusCode 200 -> do
       let
         decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-      MP.parseJsonToArrayS decodedApi
+      case decodedApi of
+        Right a -> pure (RD.Success a)
+        Left e  -> pure (RD.Failure (E.error "decoded failed"))
     SC.StatusCode 304 -> do
       let
         decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-      MP.parseJsonToArrayS decodedApi
+      case decodedApi of
+        Right a -> pure (RD.Success a)
+        Left e  -> pure (RD.Failure (E.error "decoded failed"))
     SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/tags/{tagname}
@@ -318,7 +326,9 @@ getTagPackages tagName = do
     SC.StatusCode 200 -> do
       let
         decodedApi = Arg.decodeJson (res.response :: Arg.Json)
-      MP.parseJsonToArrayS decodedApi
+      case decodedApi of
+        Right a -> pure (RD.Success a)
+        Left e  -> pure (RD.Failure (E.error "decoded failed"))
     SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/tags/{tagname}/{pkgname}

--- a/src-ui/src/Lib/Matrix2.purs
+++ b/src-ui/src/Lib/Matrix2.purs
@@ -41,10 +41,13 @@ type MatrixApi2 eff =
           (Aff
             (HalogenEffects ( ajax :: Affjax.AJAX
                             , dom :: DOM
+                            , window :: DOM.WINDOW
                             , history :: DOM.HISTORY| eff)))
 
+type MatrixE e = (ajax :: Affjax.AJAX, window :: DOM.WINDOW | e)
+
 -- /v2/idxstates with parameter min & max
-getIdxstate :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
+getIdxstate :: forall e m. MonadAff (MatrixE e) m
             => m (RD.RemoteData E.Error (Array T.PkgIdxTs))
 getIdxstate = do
   res <- liftAff (Affjax.affjax Affjax.defaultRequest {
@@ -59,7 +62,7 @@ getIdxstate = do
     SC.StatusCode _ -> pure (RD.Failure (E.error "Report Not Found"))
 
 -- /v2/idxstates/latest
-getLatestIdxstate :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
+getLatestIdxstate :: forall e m. MonadAff (MatrixE e) m
                   => m (RD.RemoteData E.Error T.PkgIdxTs)
 getLatestIdxstate = do
   res <- liftAff (Affjax.affjax Affjax.defaultRequest {
@@ -85,7 +88,8 @@ getPackages :: forall e m. MonadReader (Api.Environment e) m
             => MonadAff
                  (HalogenEffects (api :: Api.API
                                  , ajax :: Affjax.AJAX
-                                 , dom :: DOM, history :: DOM.HISTORY| e)) m
+                                 , dom :: DOM, history :: DOM.HISTORY
+                                 , window :: DOM.WINDOW | e)) m
             => m (RD.RemoteData E.Error (Array T.PackageName))
 getPackages = do
   res <- liftAff (Affjax.affjax Affjax.defaultRequest

--- a/src-ui/src/Lib/MatrixParser.purs
+++ b/src-ui/src/Lib/MatrixParser.purs
@@ -17,30 +17,6 @@ import Lib.MiscFFI
 
 import Lib.Types as T
 
-parseJsonToArrayS :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
-                   => Either String Arg.Json
-                   -> m (RD.RemoteData E.Error (Array String))
-parseJsonToArrayS (Right a) =
-  case Arg.toArray a of
-    (Just a') ->
-      case TRV.traverse Arg.toString a' of
-        (Just jStr) -> pure (RD.Success jStr)
-        Nothing     -> pure (RD.Failure (E.error "Json is not String"))
-    Nothing   -> pure (RD.Failure (E.error "Json is not Array"))
-parseJsonToArrayS (Left e) = pure $ RD.Failure (E.error e)
-
-parseJsonToArrayTS :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
-                   => Either String Arg.Json
-                   -> m (RD.RemoteData E.Error (Array T.PkgIdxTs))
-parseJsonToArrayTS (Right a) =
-  case Arg.toArray a of
-    (Just a') ->
-      case TRV.traverse Arg.toNumber a' of
-        (Just jNum) -> pure (RD.Success (Int.round <$> jNum))
-        Nothing     -> pure (RD.Failure (E.error "Json is not String"))
-    Nothing   -> pure (RD.Failure (E.error "Json is not Array"))
-parseJsonToArrayTS (Left e) = pure $ RD.Failure (E.error e)
-
 toPackageIdxTsReports :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
                       => Either String Arg.Json
                       -> m (RD.RemoteData E.Error T.PackageIdxTsReports)

--- a/src-ui/src/Lib/MatrixParser.purs
+++ b/src-ui/src/Lib/MatrixParser.purs
@@ -212,10 +212,7 @@ toCellReportDetail (Right a) =
           case SM.lookup "units" obj of
             Just unitsH ->
               case Arg.toArray unitsH of
-                Just units ->
-                  case TRV.traverse Arg.toObject units of
-                    Just uh ->  ((<$>) <<< (<$>)) show uh
-                    Nothing -> []
+                Just units -> toArrayMap <$> units
                 Nothing -> []
             Nothing -> []
       in pure $ RD.Success
@@ -367,6 +364,12 @@ toArrayString json =
   case Arg.toArray json of
     Just arr -> toString <$> arr
     Nothing -> []
+
+toArrayMap :: Arg.Json -> SM.StrMap String
+toArrayMap json =
+  case Arg.toObject json of
+    Just obj -> toString <$> obj
+    Nothing  -> SM.empty
 
 toPackageQueue  :: forall e m. MonadAff (ajax :: Affjax.AJAX | e) m
                 => Either String Arg.Json

--- a/src-ui/src/Lib/MiscFFI.js
+++ b/src-ui/src/Lib/MiscFFI.js
@@ -126,3 +126,9 @@ exports.tabs = function (t) {
     t.tabs();
   };
 };
+
+exports.scrollMaxY = function (window) {
+    return function () {
+        return window.scrollMaxY;
+    };
+};

--- a/src-ui/src/Lib/MiscFFI.purs
+++ b/src-ui/src/Lib/MiscFFI.purs
@@ -4,7 +4,7 @@ import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.JQuery (JQuery, JQueryEvent, select)
 import DOM (DOM)
-import DOM.HTML.Types (HTMLElement)
+import DOM.HTML.Types (HTMLElement, Window)
 import Data.Function.Uncurried (Fn2, Fn3, Fn4, runFn2, runFn3, runFn4)
 import Data.Maybe (Maybe(..))
 import Data.Either (Either(..))
@@ -182,3 +182,5 @@ showPrio x
   | x < 0     = "low"
   | x == 0    = "medium"
   | otherwise = "high"
+
+foreign import scrollMaxY :: forall e. Window -> Eff (dom :: DOM | e) Int

--- a/src-ui/src/Lib/MiscFFI.purs
+++ b/src-ui/src/Lib/MiscFFI.purs
@@ -8,7 +8,7 @@ import DOM.HTML.Types (HTMLElement)
 import Data.Function.Uncurried (Fn2, Fn3, Fn4, runFn2, runFn3, runFn4)
 import Data.Maybe (Maybe(..))
 import Data.Either (Either(..))
-import Prelude (Unit, id, show, unit, (/=), (<<<), (<>), (<$>), (*))
+import Prelude (Unit, otherwise, id, show, unit, (/=), (<<<), (<>), (<$>), (*), (==), (<),(>))
 import Lib.Uri (Uri)
 import Lib.Uri as Uri
 import Lib.Undefined (Undefined)
@@ -17,6 +17,7 @@ import Lib.Types as T
 import Data.Argonaut as Arg
 import Data.Traversable as TR
 import Data.Tuple as Tuple
+import Data.Tuple.Nested as TupleN
 import Data.String as Str
 import Network.RemoteData as RD
 import Data.Array as Arr
@@ -26,6 +27,7 @@ import Data.Time.Duration (Milliseconds(Milliseconds)) as DT
 import Data.DateTime (DateTime) as DT
 import Data.DateTime.Instant (instant, toDateTime) as DT
 import Data.Int as Int
+import Data.Ordering
 
 foreign import onPopstate :: forall e
    . (JQueryEvent -> Eff (dom :: DOM | e) Unit)
@@ -169,10 +171,14 @@ fromIndexToNumber Nothing        = []
 makeTuplePkgIdx :: T.PackageName -> Tuple.Tuple T.PackageName String
 makeTuplePkgIdx pkg = Tuple.Tuple (Str.takeWhile ((/=) '@') pkg) (((Str.drop 1) <<< Str.dropWhile ((/=) '@')) pkg)
 
-getLastIdx :: Array Int -> String
+getLastIdx :: Array Int -> Int
 getLastIdx arrInt=
   case Arr.last arrInt of
-    Just a -> show a
-    Nothing -> ""
+    Just a -> a
+    Nothing -> 0
 
-
+showPrio :: Int -> String
+showPrio x
+  | x < 0     = "low"
+  | x == 0    = "medium"
+  | otherwise = "high"

--- a/src-ui/src/Lib/Types.purs
+++ b/src-ui/src/Lib/Types.purs
@@ -56,6 +56,15 @@ type PackageIdxTsReports =
   , pkgversions :: SM.StrMap (Array CellReportSummary)
   }
 
+pkgIdxTsReportsEmpty :: PackageIdxTsReports
+pkgIdxTsReportsEmpty =
+  {
+    pkgname: ""
+  , idxstate: 0
+  , hcversions: []
+  , pkgversions: SM.empty
+  }
+
 type CellReportSummary =
   {
     crsT :: CellReportType
@@ -96,6 +105,20 @@ type UnitIdInfo =
   , uiiLibDeps :: SM.StrMap (Array UUID)
   , uiiExeDeps :: SM.StrMap (Array UUID)
   }
+
+unitIdInfoEmpty :: UnitIdInfo
+unitIdInfoEmpty =
+  {
+    uiiId: ""
+  , uiiHcVer: ""
+  , uiiPkgname: ""
+  , uiiPkgver: ""
+  , uiiStatus: ""
+  , uiiLogmsg: ""
+  , uiiLibDeps: SM.empty
+  , uiiExeDeps: SM.empty
+  }
+
 -- /v2/queue || /v2/queue/{pkgname} || /v2/queue/{pkgname}/{idxstate}
 type PackageQueue =
   {

--- a/src-ui/src/Lib/Types.purs
+++ b/src-ui/src/Lib/Types.purs
@@ -15,10 +15,10 @@ import Data.Tuple.Nested as TupleN
 type Username = String
 type PackageName = String
 type VersionName = String
-type Revision = Word
+type Revision = Int
 type TagName = String
 type TagsWithPackages = SM.StrMap (Array PackageName)
-type PkgVerPfx = Array Word
+type PkgVerPfx = Array Int
 type HackageUrl = String
 type RevisionUrl = String
 type HdiffUrl = String
@@ -27,7 +27,7 @@ type Word = Int
 type PkgIdxTs = Int
 type PackageTS = String
 type HCVer = String
-type PackageHistory = TupleN.Tuple4 PkgIdxTs VersionName Revision Username
+
 type CellReportType = String
 type BuildStatus = String
 type BuildLog = String
@@ -81,6 +81,7 @@ type CellReportDetail =
   }
 
 -- /v2/packages/{pkgname}/history
+type PackageHistory = TupleN.Tuple4 PkgIdxTs VersionName Revision Username
 type PackageHistories = Array PackageHistory
 
 -- /v2/units/{unitid}
@@ -98,7 +99,7 @@ type UnitIdInfo =
 -- /v2/queue || /v2/queue/{pkgname} || /v2/queue/{pkgname}/{idxstate}
 type PackageQueue =
   {
-    priority :: Word
+    priority :: Int
   , modified :: PackageTS
   , pkgname :: PackageName
   , idxstate :: PkgIdxTs


### PR DESCRIPTION
One thing that need to be discussed is regarding the api call for `/api/v2/units/{unitid}` when the cell has `se` status.

the problem that I notice is when the api call for `/api/v2/packages/{pkgname}/reports/{idxstate}/{pkgver}/{hcver}/` has units with type `Array (StrMap String)`, then we have to call each of unit using `/api/v2/units/{unitid}` call.. however, it will create type `[ m (RemoteData Error UnitInfo) ]`. It is possible to do traversals, but it will cause another monadic recursive as it happened before.