### PR TITLE
V3 routingpackage

### DIFF
--- a/src-ui.v3/matrix-ui.cabal
+++ b/src-ui.v3/matrix-ui.cabal
@@ -38,6 +38,10 @@ executable matrix-ui
     , vector                    ^>= 0.12.0.1
     , uuid-types                ^>= 1.0.3
     , servant                   ^>= 0.16
+    , primitive                 ^>= 0.6.4.0
+    , monad-control             ^>= 1.0.2.3
+    , mtl                       ^>= 2.2.2
+    , ref-tf                    ^>= 0.4
 
     -- unreleased Git snapshots of deps; see cabal.project for provenance
     -- , ghcjs-dom-jsffi

--- a/src-ui.v3/src/API.hs
+++ b/src-ui.v3/src/API.hs
@@ -71,7 +71,7 @@ module API
 import           PkgId
 
 import           Control.Monad    (fail)
-import           Data.Aeson       (FromJSON, ToJSON, decode)
+import           Data.Aeson       (FromJSON, decode)
 import qualified Data.Aeson       as J
 import qualified Data.Aeson.Types as J
 import qualified Data.Char        as C

--- a/src-ui.v3/src/Main.hs
+++ b/src-ui.v3/src/Main.hs
@@ -319,7 +319,7 @@ bodyElement4 = mdo
         let dynPkgTags = pkgTagList <$> dynTagPkgs
         packagesPageWidget dynPackages0 dynTags dynPkgTags
 
-    RoutePackage pn -> pure $ do
+    RoutePackage (pn, idxSt) -> pure $ do
         el "h2" $ text (pkgNToText pn)
         el "p" $ el "em" $ elAttr "a" ("href" =: ("https://hackage.haskell.org/package/" <> pkgNToText pn)) $
           do text "(view on Hackage)"
@@ -457,7 +457,7 @@ bodyElement4 = mdo
 data FragRoute = RouteHome
                | RouteQueue
                | RoutePackages
-               | RoutePackage PkgN
+               | RoutePackage (PkgN, Maybe Int)
                | RouteUser UserName
                | RouteUnknown T.Text
                deriving (Eq)
@@ -472,8 +472,8 @@ decodeFrag frag = case frag of
 
     _ | Just sfx <- T.stripPrefix "#/package/" frag
       , not (T.null frag)
-      , Just pn <- pkgNFromText sfx
-        -> RoutePackage pn
+      , (Just pn, idx) <- pkgNFromText sfx
+        -> RoutePackage (pn , idx)
 
       | Just sfx <- T.stripPrefix "#/user/" frag
       , not (T.null frag)
@@ -760,8 +760,8 @@ splitInfixPkg stripSJ pkg = (frontT, midT, backT)
 
 calcMatch :: JSS.JSString  -> JSS.JSString -> (Map.Map Text (), Map.Map Text (Text,Text,Text))
 calcMatch sJss pkg
-  | stripSJ == pkg = (Map.singleton (JSS.textFromJSString pkg) (), Map.empty)
-  | otherwise      = filterPkgSearch stripSJ pkg
+  | stripSJ == pkg             = (Map.singleton (JSS.textFromJSString pkg) (), Map.empty)
+  | otherwise                  = filterPkgSearch sJss pkg
   where
     stripSJ = stripSearch sJss
 

--- a/src-ui.v3/src/Main.hs
+++ b/src-ui.v3/src/Main.hs
@@ -380,7 +380,8 @@ app dynFrag = do
         ddReports <- el "p" $ do
           evQButton <- button "Queue a build"
           text " for the index-state "
-          tmp <- routePkgIdxTs pn (PkgIdxTs 0) (current dynReports) xs ddCfg
+          uniqReport <- holdUniqDyn dynReports
+          tmp <- routePkgIdxTs pn (PkgIdxTs 0) uniqReport xs ddCfg
           text " shown below"
 
           _ <- putQueue (constDyn $ Right pn) (Right <$> _dropdown_value tmp) (constDyn $ Right (QEntryUpd (-1))) evQButton

--- a/src-ui.v3/src/Main.hs
+++ b/src-ui.v3/src/Main.hs
@@ -114,7 +114,7 @@ bodyElement4 = do
   -- ticker1 <- tickLossy 1 =<< liftIO getCurrentTime
 --    ticker1cnt <- count ticker1
 
-app :: forall t r m. (SetRoute t (NonEmpty FragRoute) m, SupportsServantReflex t m, MonadFix m, MonadIO m, MonadHold t m, PostBuild t m, DomBuilder t m, Adjustable t m, DomBuilderSpace m ~ GhcjsDomSpace) 
+app :: forall t m. (SetRoute t FragRoute m, SupportsServantReflex t m, MonadFix m, MonadIO m, MonadHold t m, PostBuild t m, DomBuilder t m, Adjustable t m, DomBuilderSpace m ~ GhcjsDomSpace) 
     => Dynamic t FragRoute
     -> m ()
 app dynFrag = do
@@ -706,22 +706,6 @@ findInitialDropDown (Just idx) pkgSet = if Set.member idx pkgSet
                                         then Set.foldr (\a b -> if a == b then a else b) idx pkgSet
                                         else Set.findMax pkgSet
 findInitialDropDown Nothing pkgSet    = Set.findMax pkgSet
-
-switchPkgRoute :: Set PkgIdxTs -> URI ->  PkgIdxTs -> Maybe URI 
-switchPkgRoute setPkgIdx oldRoute (PkgIdxTs 0) = Nothing
-switchPkgRoute setPkgIdx oldRoute idxChange =
-  let routeS  = (T.pack . uriFragment) oldRoute
-      rootURI = "#/package/"
-  in case T.stripPrefix rootURI routeS of
-    Just sfx | (Just pkgN, Just pkgIdx) <- pkgNFromText sfx
-             , True <- idxChange /= pkgIdx
-             , True <- not (Set.null setPkgIdx)
-             , Just setMax <- Set.lookupMax setPkgIdx
-               -> if setMax == idxChange
-                  then Nothing
-                  else parseURI . T.unpack $ rootURI <> (pkgNToText pkgN) <> (T.pack "@") <> (idxTsToText idxChange)
-             | otherwise -> Nothing
-    Nothing  -> Nothing
 
 toggleTagSet :: TagN -> Set.Set TagN -> Set.Set TagN
 toggleTagSet tn st = if Set.member tn st then Set.delete tn st else Set.insert tn st

--- a/src-ui.v3/src/PkgId.hs
+++ b/src-ui.v3/src/PkgId.hs
@@ -33,7 +33,6 @@ module PkgId
     , PkgRev
 
     , UserName
-    , FragRoute(..), decodeFrag
     ) where
 
 import           Control.Monad                (fail)
@@ -176,35 +175,7 @@ matchesEmpty = Matches { matchesInput = T.empty, matchesExact = Map.empty, match
 
 ---------------------------------
 
-data FragRoute = RouteHome
-               | RouteQueue
-               | RoutePackages
-               | RoutePackage (PkgN, Maybe PkgIdxTs)
-               | RouteUser UserName
-               | RouteUnknown T.Text
-               deriving (Eq, Ord)
 
-decodeFrag :: T.Text -> FragRoute
-decodeFrag frag = case frag of
-    ""           -> RouteHome
-    "#"          -> RouteHome
-    "#/"         -> RouteHome
-    "#/queue"    -> RouteQueue
-    "#/packages" -> RoutePackages
-
-    _ | Just sfx <- T.stripPrefix "#/package/" frag
-      , not (T.null frag)
-      , (Just pn, idx) <- pkgNFromText sfx
-        -> RoutePackage (pn , idx)
-
-      | Just sfx <- T.stripPrefix "#/user/" frag
-      , not (T.null frag)
-      , T.all (\c -> C.isAsciiLower c || C.isAsciiUpper c || C.isDigit c || c == '_') sfx
-        -> RouteUser sfx
-
-      | otherwise -> RouteUnknown frag
-
---encodeFrag :: FragRoute -> Maybe 
 
 
   

--- a/src-ui.v3/src/PkgId.hs
+++ b/src-ui.v3/src/PkgId.hs
@@ -33,6 +33,7 @@ module PkgId
     , PkgRev
 
     , UserName
+    , FragRoute(..), decodeFrag
     ) where
 
 import           Control.Monad                (fail)
@@ -171,6 +172,39 @@ data Matches = Matches
   deriving (Eq,Ord)
 
 matchesEmpty :: Matches
-matchesEmpty = Matches { matchesInput = T.empty, matchesExact = Map.empty, matchesInfix = Map.empty} 
+matchesEmpty = Matches { matchesInput = T.empty, matchesExact = Map.empty, matchesInfix = Map.empty}
+
+---------------------------------
+
+data FragRoute = RouteHome
+               | RouteQueue
+               | RoutePackages
+               | RoutePackage (PkgN, Maybe PkgIdxTs)
+               | RouteUser UserName
+               | RouteUnknown T.Text
+               deriving (Eq, Ord)
+
+decodeFrag :: T.Text -> FragRoute
+decodeFrag frag = case frag of
+    ""           -> RouteHome
+    "#"          -> RouteHome
+    "#/"         -> RouteHome
+    "#/queue"    -> RouteQueue
+    "#/packages" -> RoutePackages
+
+    _ | Just sfx <- T.stripPrefix "#/package/" frag
+      , not (T.null frag)
+      , (Just pn, idx) <- pkgNFromText sfx
+        -> RoutePackage (pn , idx)
+
+      | Just sfx <- T.stripPrefix "#/user/" frag
+      , not (T.null frag)
+      , T.all (\c -> C.isAsciiLower c || C.isAsciiUpper c || C.isDigit c || c == '_') sfx
+        -> RouteUser sfx
+
+      | otherwise -> RouteUnknown frag
+
+--encodeFrag :: FragRoute -> Maybe 
+
 
   

--- a/src-ui.v3/src/Router.hs
+++ b/src-ui.v3/src/Router.hs
@@ -1,0 +1,258 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FunctionalDependencies #-}
+
+module Router 
+  ( SetRouteT(..)
+  , SetRoute(..)
+  , runSetRouteT
+  , mapSetRouteT
+  , switchPkgRoute
+  , routeLink
+  , routePkgIdxTs
+  , runRouteViewT
+  ) where
+
+import           Prelude hiding ((.), id)
+import           Control.Category (Category (..), (.))
+import           Control.Lens hiding (Bifunctor, bimap, universe, element)
+import           Control.Monad ((<=<))
+import           Control.Monad.Fix
+import           Control.Monad.Primitive
+import           Control.Monad.Reader
+import           Control.Monad.Ref
+import           Control.Monad.Trans.Control
+import           Data.Coerce
+import qualified Data.List.NonEmpty        as NE
+import           Data.List.NonEmpty        (NonEmpty)
+import qualified Data.Map.Strict           as Map
+import           Data.Monoid
+import           Data.Proxy
+import qualified Data.Set                  as Set
+import           Data.Set                  (Set)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Functor.Compose
+import           Reflex.Class
+import           Reflex.Host.Class
+import           Reflex.PostBuild.Class
+import           Reflex.TriggerEvent.Class
+import           Reflex.PerformEvent.Class
+import           Reflex.EventWriter.Class
+import           Reflex.EventWriter.Base
+import           Reflex.Dynamic
+import           Reflex.Dom.Builder.Class
+import           Data.Type.Coercion
+import           Language.Javascript.JSaddle
+import           Reflex.Dom.Core
+import qualified GHCJS.DOM.Types as DOM
+import           Network.URI
+import           Data.Maybe (Maybe(..), fromMaybe, isJust)
+import qualified Data.List as L
+
+import           PkgId
+
+newtype SetRouteT t r m a = SetRouteT { unSetRouteT :: EventWriterT t r m a }
+  deriving (Functor, Applicative, Monad, MonadFix, MonadTrans, MonadIO, NotReady t, MonadHold t, MonadSample t, PostBuild t, TriggerEvent t, MonadReflexCreateTrigger t, HasDocument, DomRenderHook t)
+
+instance (Semigroup r, MonadFix m, MonadHold t m, DomBuilder t m) => DomBuilder t (SetRouteT t r m) where
+  type DomBuilderSpace (SetRouteT t r m) = DomBuilderSpace m
+  element t cfg child = SetRouteT $ element t cfg $ unSetRouteT child
+  inputElement = lift . inputElement
+  textAreaElement = lift . textAreaElement
+  selectElement cfg child = SetRouteT $ selectElement cfg $ unSetRouteT child
+
+instance HasJSContext m => HasJSContext (SetRouteT t r m) where
+  type JSContextPhantom (SetRouteT t r m) = JSContextPhantom m
+  askJSContext = lift askJSContext
+
+mapSetRouteT :: (forall x. m x -> n x) -> SetRouteT t r m a -> SetRouteT t r n a
+mapSetRouteT f (SetRouteT x) = SetRouteT (mapEventWriterT f x)
+
+runSetRouteT :: (Semigroup r, Reflex t, Monad m) => SetRouteT t r m a -> m (a, Event t r)
+runSetRouteT = runEventWriterT . unSetRouteT
+
+class Reflex t => SetRoute t r m | m -> t r where
+  setRoute :: Event t r -> m ()
+  setRoute = setRoute
+
+instance (Semigroup r, Reflex t, Monad m) => SetRoute t r (SetRouteT t r m) where
+  setRoute = SetRouteT . tellEvent
+
+instance (Monad m, SetRoute t r m) => SetRoute t r (QueryT t q m)
+
+instance (Monad m, SetRoute t r m) => SetRoute t r (EventWriterT t w m)
+
+--instance (Monad m, SetRoute t r m) => SetRoute t r (RoutedT t r' m)
+
+instance (Monad m, SetRoute t r m) => SetRoute t r (ReaderT r' m)
+
+instance Requester t m => Requester t (SetRouteT t r m) where
+  type Request (SetRouteT t r m) = Request m
+  type Response (SetRouteT t r m) = Response m
+  requesting = SetRouteT . requesting
+  requesting_ = SetRouteT . requesting_
+
+instance (Monad m, SetRoute t r m) => SetRoute t r (RequesterT t req rsp m)
+
+#ifndef ghcjs_HOST_OS
+deriving instance MonadJSM m => MonadJSM (SetRouteT t r m)
+#endif
+
+instance PerformEvent t m => PerformEvent t (SetRouteT t r m) where
+  type Performable (SetRouteT t r m) = Performable m
+  performEvent = lift . performEvent
+  performEvent_ = lift . performEvent_
+
+instance MonadRef m => MonadRef (SetRouteT t r m) where
+  type Ref (SetRouteT t r m) = Ref m
+  newRef = lift . newRef
+  readRef = lift . readRef
+  writeRef r = lift . writeRef r
+
+instance HasJS x m => HasJS x (SetRouteT t r m) where
+  type JSX (SetRouteT t r m) = JSX m
+  liftJS = lift . liftJS
+
+instance PrimMonad m => PrimMonad (SetRouteT t r m ) where
+  type PrimState (SetRouteT t r m) = PrimState m
+  primitive = lift . primitive
+
+instance (Semigroup r, MonadHold t m, Adjustable t m) => Adjustable t (SetRouteT t r m) where
+  runWithReplace a0 a' = SetRouteT $ runWithReplace (coerce a0) $ coerceEvent a'
+  traverseIntMapWithKeyWithAdjust f a0 a' = SetRouteT $ traverseIntMapWithKeyWithAdjust (coerce f) (coerce a0) $ coerce a'
+  traverseDMapWithKeyWithAdjust f a0 a' = SetRouteT $ traverseDMapWithKeyWithAdjust (\k v -> coerce $ f k v) (coerce a0) $ coerce a'
+  traverseDMapWithKeyWithAdjustWithMove f a0 a' = SetRouteT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> coerce $ f k v) (coerce a0) $ coerce a'
+
+instance (Monad m, MonadQuery t vs m) => MonadQuery t vs (SetRouteT t r m) where
+  tellQueryIncremental = lift . tellQueryIncremental
+  askQueryResult = lift askQueryResult
+  queryIncremental = lift . queryIncremental
+
+switchPkgRoute :: Set PkgIdxTs -> URI ->  PkgIdxTs -> Maybe URI 
+switchPkgRoute setPkgIdx oldRoute (PkgIdxTs 0) = Nothing
+switchPkgRoute setPkgIdx oldRoute idxChange =
+  let routeS  = (T.pack . uriFragment) oldRoute
+      rootURI = "#/package/"
+  in case T.stripPrefix rootURI routeS of
+    Just sfx | (Just pkgN, Just pkgIdx) <- pkgNFromText sfx
+             , True <- idxChange /= pkgIdx
+             , True <- not (Set.null setPkgIdx)
+             , Just setMax <- Set.lookupMax setPkgIdx
+               -> if setMax == idxChange
+                  then Nothing
+                  else parseURI . T.unpack $ rootURI <> (pkgNToText pkgN) <> (T.pack "@") <> (idxTsToText idxChange)
+             | otherwise -> Nothing
+    Nothing  -> Nothing
+
+routeLink :: forall t m a route. ( DomBuilder t m, SetRoute t (NonEmpty FragRoute) m) 
+          => Bool -- PreventDefault?
+          -> Text -- Target route
+          -> m a -- Child widget
+          -> m a
+routeLink True r w = do
+  let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
+        & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (\_ -> preventDefault)
+        & elementConfig_initialAttributes .~ "href" =: r
+  (e, a) <- element "a" cfg w
+  setRoute $ (((decodeFrag r) NE.:| []) <$ domEvent Click e) 
+  return a
+routeLink False r w = do
+  let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
+        & elementConfig_initialAttributes .~ "href" =: r
+  (e, a) <- element "a" cfg w
+  setRoute $ (((decodeFrag r) NE.:| []) <$ domEvent Click e) 
+  return a
+
+routePkgIdxTs :: forall t m. ( PostBuild t m, MonadHold t m, MonadFix m, DomBuilder t m, SetRoute t (NonEmpty FragRoute) m) 
+              => PkgN
+              -> PkgIdxTs
+              -> Behavior t (Set PkgIdxTs)
+              -> Dynamic t (Map.Map PkgIdxTs Text) 
+              -> DropdownConfig t PkgIdxTs
+              -> m (Dropdown t PkgIdxTs)
+routePkgIdxTs pn k0 setIdx opt ddConf = do
+  dd <- dropdown k0 opt ddConf
+  let evDD = attach setIdx (updated $ dd ^. dropdown_value)
+  setRoute $ ((\val -> (createRoutePackage pn val) NE.:| []) <$> evDD)
+  pure dd
+
+createRoutePackage :: PkgN -> (Set PkgIdxTs, PkgIdxTs) -> FragRoute
+createRoutePackage pn (_, PkgIdxTs 0) = RoutePackage (pn, Nothing)
+createRoutePackage pn (setIdx, pkgIdx) 
+  | Just maxIdx <- Set.lookupMax setIdx
+  , True     <- maxIdx /= pkgIdx
+  = RoutePackage (pn, Just pkgIdx)
+  | otherwise = RoutePackage (pn, Nothing)
+
+runRouteViewT  :: forall t m a. (TriggerEvent t m, PerformEvent t m, MonadHold t m, MonadJSM m, MonadJSM (Performable m), MonadFix m)
+               => (Dynamic t FragRoute -> SetRouteT t (NonEmpty FragRoute) m a)
+               -> m a
+runRouteViewT app = mdo
+  historyState <- manageHistory $ HistoryCommand_PushState <$> setState
+  dynLoc <- browserHistoryWith getLocationUri
+  (result, changeStateE) <- runSetRouteT $ app route -- changeStateE :: Event t (NonEmpty Fragroute)
+  let 
+    route :: Dynamic t FragRoute
+    route = decodeFrag . T.pack . uriFragment <$> dynLoc
+
+    f  (currentHistoryState, oldR) chStateE = -- chState :: NonEmpty Fragroute
+      let newRoute = switchPkgRoute' oldR chStateE
+          oldRoute = case encodeFrag oldR of
+                       (Just a) -> a
+                       Nothing  -> T.empty
+      in 
+        HistoryStateUpdate
+        { _historyStateUpdate_state = DOM.SerializedScriptValue jsNull
+        , _historyStateUpdate_title = ""
+        , _historyStateUpdate_uri   = applyEncoding oldRoute newRoute (_historyItem_uri currentHistoryState)
+        }
+    setState = attachWith f ( (,) <$> current historyState <*> current route) changeStateE
+  pure result
+
+switchPkgRoute' :: FragRoute -> NonEmpty FragRoute -> Text
+switchPkgRoute' oldFrag nEFrag
+  | (fragR, _) <- NE.uncons nEFrag
+  , Just fResult <- encodeFrag fragR
+    = fResult
+  | Just oldResult <- encodeFrag oldFrag
+    = oldResult
+  | otherwise = T.empty
+  
+encodeFrag :: FragRoute -> Maybe Text
+encodeFrag RouteHome = Just "#/"
+encodeFrag RouteQueue = Just "#/queue"
+encodeFrag RoutePackages = Just "#/packages"
+encodeFrag (RoutePackage (pkg, maybeIndex))
+  | Just indexTs <- maybeIndex
+    = Just $ "#/package/" <> (pkgNToText pkg) <> "@" <> (idxTsToText indexTs)
+  | otherwise = Just $ "#/package/" <> (pkgNToText pkg)
+encodeFrag (RouteUser usr) = Just $ "#/user/" <> usr
+encodeFrag (RouteUnknown _) = Nothing
+
+applyEncoding :: Text -> Text -> URI -> Maybe URI
+applyEncoding oldR newR u 
+  | oldR /= newR = Just $ u { uriFragment = T.unpack newR }
+  | otherwise    = Nothing

--- a/src-ui.v3/src/Router.hs
+++ b/src-ui.v3/src/Router.hs
@@ -33,20 +33,18 @@ module Router
   , routeLink
   , routePkgIdxTs
   , runRouteViewT
+  , FragRoute(..), decodeFrag
   ) where
 
 import           Prelude hiding ((.), id)
 import           Control.Category (Category (..), (.))
 import           Control.Lens hiding (Bifunctor, bimap, universe, element)
-import           Control.Monad ((<=<))
 import           Control.Monad.Fix
 import           Control.Monad.Primitive
 import           Control.Monad.Reader
 import           Control.Monad.Ref
-import           Control.Monad.Trans.Control
+import qualified Data.Char                 as C
 import           Data.Coerce
-import qualified Data.List.NonEmpty        as NE
-import           Data.List.NonEmpty        (NonEmpty)
 import qualified Data.Map.Strict           as Map
 import           Data.Monoid
 import           Data.Proxy
@@ -54,7 +52,6 @@ import qualified Data.Set                  as Set
 import           Data.Set                  (Set)
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Data.Functor.Compose
 import           Reflex.Class
 import           Reflex.Host.Class
 import           Reflex.PostBuild.Class
@@ -62,22 +59,27 @@ import           Reflex.TriggerEvent.Class
 import           Reflex.PerformEvent.Class
 import           Reflex.EventWriter.Class
 import           Reflex.EventWriter.Base
-import           Reflex.Dynamic
 import           Reflex.Dom.Builder.Class
-import           Data.Type.Coercion
 import           Language.Javascript.JSaddle
 import           Reflex.Dom.Core
 import qualified GHCJS.DOM.Types as DOM
 import           Network.URI
-import           Data.Maybe (Maybe(..), fromMaybe, isJust)
-import qualified Data.List as L
+import           Data.Maybe (Maybe(..), fromMaybe)
 
 import           PkgId
 
-newtype SetRouteT t r m a = SetRouteT { unSetRouteT :: EventWriterT t r m a }
+data FragRoute = RouteHome
+               | RouteQueue
+               | RoutePackages
+               | RoutePackage (PkgN, Maybe PkgIdxTs)
+               | RouteUser UserName
+               | RouteUnknown T.Text
+               deriving (Eq, Ord)
+
+newtype SetRouteT t r m a = SetRouteT { unSetRouteT :: EventWriterT t (Endo r) m a }
   deriving (Functor, Applicative, Monad, MonadFix, MonadTrans, MonadIO, NotReady t, MonadHold t, MonadSample t, PostBuild t, TriggerEvent t, MonadReflexCreateTrigger t, HasDocument, DomRenderHook t)
 
-instance (Semigroup r, MonadFix m, MonadHold t m, DomBuilder t m) => DomBuilder t (SetRouteT t r m) where
+instance (MonadFix m, MonadHold t m, DomBuilder t m) => DomBuilder t (SetRouteT t r m) where
   type DomBuilderSpace (SetRouteT t r m) = DomBuilderSpace m
   element t cfg child = SetRouteT $ element t cfg $ unSetRouteT child
   inputElement = lift . inputElement
@@ -91,15 +93,15 @@ instance HasJSContext m => HasJSContext (SetRouteT t r m) where
 mapSetRouteT :: (forall x. m x -> n x) -> SetRouteT t r m a -> SetRouteT t r n a
 mapSetRouteT f (SetRouteT x) = SetRouteT (mapEventWriterT f x)
 
-runSetRouteT :: (Semigroup r, Reflex t, Monad m) => SetRouteT t r m a -> m (a, Event t r)
+runSetRouteT :: (Reflex t, Monad m) => SetRouteT t r m a -> m (a, Event t (Endo r))
 runSetRouteT = runEventWriterT . unSetRouteT
 
 class Reflex t => SetRoute t r m | m -> t r where
-  setRoute :: Event t r -> m ()
+  setRoute :: Event t (r -> r) -> m ()
   setRoute = setRoute
 
-instance (Semigroup r, Reflex t, Monad m) => SetRoute t r (SetRouteT t r m) where
-  setRoute = SetRouteT . tellEvent
+instance (Reflex t, Monad m) => SetRoute t r (SetRouteT t r m) where
+  setRoute = SetRouteT . tellEvent . fmap Endo
 
 instance (Monad m, SetRoute t r m) => SetRoute t r (QueryT t q m)
 
@@ -140,7 +142,7 @@ instance PrimMonad m => PrimMonad (SetRouteT t r m ) where
   type PrimState (SetRouteT t r m) = PrimState m
   primitive = lift . primitive
 
-instance (Semigroup r, MonadHold t m, Adjustable t m) => Adjustable t (SetRouteT t r m) where
+instance (MonadHold t m, Adjustable t m) => Adjustable t (SetRouteT t r m) where
   runWithReplace a0 a' = SetRouteT $ runWithReplace (coerce a0) $ coerceEvent a'
   traverseIntMapWithKeyWithAdjust f a0 a' = SetRouteT $ traverseIntMapWithKeyWithAdjust (coerce f) (coerce a0) $ coerce a'
   traverseDMapWithKeyWithAdjust f a0 a' = SetRouteT $ traverseDMapWithKeyWithAdjust (\k v -> coerce $ f k v) (coerce a0) $ coerce a'
@@ -151,23 +153,7 @@ instance (Monad m, MonadQuery t vs m) => MonadQuery t vs (SetRouteT t r m) where
   askQueryResult = lift askQueryResult
   queryIncremental = lift . queryIncremental
 
-switchPkgRoute :: Set PkgIdxTs -> URI ->  PkgIdxTs -> Maybe URI 
-switchPkgRoute setPkgIdx oldRoute (PkgIdxTs 0) = Nothing
-switchPkgRoute setPkgIdx oldRoute idxChange =
-  let routeS  = (T.pack . uriFragment) oldRoute
-      rootURI = "#/package/"
-  in case T.stripPrefix rootURI routeS of
-    Just sfx | (Just pkgN, Just pkgIdx) <- pkgNFromText sfx
-             , True <- idxChange /= pkgIdx
-             , True <- not (Set.null setPkgIdx)
-             , Just setMax <- Set.lookupMax setPkgIdx
-               -> if setMax == idxChange
-                  then Nothing
-                  else parseURI . T.unpack $ rootURI <> (pkgNToText pkgN) <> (T.pack "@") <> (idxTsToText idxChange)
-             | otherwise -> Nothing
-    Nothing  -> Nothing
-
-routeLink :: forall t m a route. ( DomBuilder t m, SetRoute t (NonEmpty FragRoute) m) 
+routeLink :: forall t m a. ( DomBuilder t m, SetRoute t FragRoute m) 
           => Bool -- PreventDefault?
           -> Text -- Target route
           -> m a -- Child widget
@@ -177,16 +163,16 @@ routeLink True r w = do
         & elementConfig_eventSpec %~ addEventSpecFlags (Proxy :: Proxy (DomBuilderSpace m)) Click (\_ -> preventDefault)
         & elementConfig_initialAttributes .~ "href" =: r
   (e, a) <- element "a" cfg w
-  setRoute $ (((decodeFrag r) NE.:| []) <$ domEvent Click e) 
+  setRoute $ (switchPkgRoute (Just $ decodeFrag r)) <$ domEvent Click e
   return a
 routeLink False r w = do
   let cfg = (def :: ElementConfig EventResult t (DomBuilderSpace m))
         & elementConfig_initialAttributes .~ "href" =: r
   (e, a) <- element "a" cfg w
-  setRoute $ (((decodeFrag r) NE.:| []) <$ domEvent Click e) 
+  setRoute $ (switchPkgRoute (Just $ decodeFrag r)) <$ domEvent Click e 
   return a
 
-routePkgIdxTs :: forall t m. ( PostBuild t m, MonadHold t m, MonadFix m, DomBuilder t m, SetRoute t (NonEmpty FragRoute) m) 
+routePkgIdxTs :: forall t m. (PostBuild t m, MonadHold t m, MonadFix m, DomBuilder t m, SetRoute t FragRoute m) 
               => PkgN
               -> PkgIdxTs
               -> Behavior t (Set PkgIdxTs)
@@ -196,50 +182,48 @@ routePkgIdxTs :: forall t m. ( PostBuild t m, MonadHold t m, MonadFix m, DomBuil
 routePkgIdxTs pn k0 setIdx opt ddConf = do
   dd <- dropdown k0 opt ddConf
   let evDD = attach setIdx (updated $ dd ^. dropdown_value)
-  setRoute $ ((\val -> (createRoutePackage pn val) NE.:| []) <$> evDD)
+  setRoute $ (switchPkgRoute . (\tup -> createRoutePackage pn tup)) <$> evDD
   pure dd
 
-createRoutePackage :: PkgN -> (Set PkgIdxTs, PkgIdxTs) -> FragRoute
-createRoutePackage pn (_, PkgIdxTs 0) = RoutePackage (pn, Nothing)
+createRoutePackage :: PkgN -> (Set PkgIdxTs, PkgIdxTs) -> Maybe FragRoute
+createRoutePackage pn (_, PkgIdxTs 0) = Just $ RoutePackage (pn, Nothing)
 createRoutePackage pn (setIdx, pkgIdx) 
   | Just maxIdx <- Set.lookupMax setIdx
   , True     <- maxIdx /= pkgIdx
-  = RoutePackage (pn, Just pkgIdx)
-  | otherwise = RoutePackage (pn, Nothing)
+  = Just $ RoutePackage (pn, Just pkgIdx)
+  | otherwise = Just $ RoutePackage (pn, Nothing)
 
 runRouteViewT  :: forall t m a. (TriggerEvent t m, PerformEvent t m, MonadHold t m, MonadJSM m, MonadJSM (Performable m), MonadFix m)
-               => (Dynamic t FragRoute -> SetRouteT t (NonEmpty FragRoute) m a)
+               => (Dynamic t FragRoute -> SetRouteT t FragRoute m a)
                -> m a
 runRouteViewT app = mdo
   historyState <- manageHistory $ HistoryCommand_PushState <$> setState
-  dynLoc <- browserHistoryWith getLocationUri
-  (result, changeStateE) <- runSetRouteT $ app route -- changeStateE :: Event t (NonEmpty Fragroute)
+  --dynLoc <- browserHistoryWith getLocationUri
+  (result, changeStateE) <- runSetRouteT $ app route -- changeStateE :: Event t (Endo (Fragroute -> FragRoute)
   let 
+    dynLoc = _historyItem_uri <$> historyState
+
     route :: Dynamic t FragRoute
     route = decodeFrag . T.pack . uriFragment <$> dynLoc
 
-    f  (currentHistoryState, oldR) chStateE = -- chState :: NonEmpty Fragroute
-      let newRoute = switchPkgRoute' oldR chStateE
-          oldRoute = case encodeFrag oldR of
-                       (Just a) -> a
-                       Nothing  -> T.empty
-      in 
-        HistoryStateUpdate
-        { _historyStateUpdate_state = DOM.SerializedScriptValue jsNull
-        , _historyStateUpdate_title = ""
-        , _historyStateUpdate_uri   = applyEncoding oldRoute newRoute (_historyItem_uri currentHistoryState)
-        }
-    setState = attachWith f ( (,) <$> current historyState <*> current route) changeStateE
+    f  (currentHistoryState, oldR) chStateE = -- chState :: Endo (FragRoute -> FragRoute)
+      let newRoute = encodeFrag $ appEndo chStateE oldR
+          --oldRoute = case encodeFrag oldR of
+          --             (Just a) -> a
+          --             Nothing  -> T.empty
+      in do
+        oldRoute <- encodeFrag oldR
+        newUri   <- applyEncoding oldRoute newRoute (_historyItem_uri currentHistoryState)
+        pure $ HistoryStateUpdate
+               { _historyStateUpdate_state = DOM.SerializedScriptValue jsNull
+               , _historyStateUpdate_title = ""
+               , _historyStateUpdate_uri   = Just newUri
+               }
+    setState = fmapMaybe id $ attachWith f ( (,) <$> current historyState <*> current route) changeStateE
   pure result
 
-switchPkgRoute' :: FragRoute -> NonEmpty FragRoute -> Text
-switchPkgRoute' oldFrag nEFrag
-  | (fragR, _) <- NE.uncons nEFrag
-  , Just fResult <- encodeFrag fragR
-    = fResult
-  | Just oldResult <- encodeFrag oldFrag
-    = oldResult
-  | otherwise = T.empty
+switchPkgRoute :: Maybe FragRoute -> FragRoute -> FragRoute
+switchPkgRoute newFrag oldFrag = fromMaybe oldFrag newFrag
   
 encodeFrag :: FragRoute -> Maybe Text
 encodeFrag RouteHome = Just "#/"
@@ -252,7 +236,28 @@ encodeFrag (RoutePackage (pkg, maybeIndex))
 encodeFrag (RouteUser usr) = Just $ "#/user/" <> usr
 encodeFrag (RouteUnknown _) = Nothing
 
-applyEncoding :: Text -> Text -> URI -> Maybe URI
-applyEncoding oldR newR u 
+applyEncoding :: Text -> Maybe Text -> URI -> Maybe URI
+applyEncoding _ Nothing _ = Nothing
+applyEncoding oldR (Just newR) u 
   | oldR /= newR = Just $ u { uriFragment = T.unpack newR }
   | otherwise    = Nothing
+
+decodeFrag :: T.Text -> FragRoute
+decodeFrag frag = case frag of
+    ""           -> RouteHome
+    "#"          -> RouteHome
+    "#/"         -> RouteHome
+    "#/queue"    -> RouteQueue
+    "#/packages" -> RoutePackages
+
+    _ | Just sfx <- T.stripPrefix "#/package/" frag
+      , not (T.null frag)
+      , (Just pn, idx) <- pkgNFromText sfx
+        -> RoutePackage (pn , idx)
+
+      | Just sfx <- T.stripPrefix "#/user/" frag
+      , not (T.null frag)
+      , T.all (\c -> C.isAsciiLower c || C.isAsciiUpper c || C.isDigit c || c == '_') sfx
+        -> RouteUser sfx
+
+      | otherwise -> RouteUnknown frag


### PR DESCRIPTION
The idea of this PR is to have what mentioned in https://github.com/haskell-CI/hackage-matrix-builder/issues/55, such as:
1. Go to specific  index state based on the URI provided by the user in the following format `packageName@timestamp` (e.g. `ace@1417176136`)
2. The URI will also change based on dropdown selected in the package menu
3. One thing that should be in the behavior of this PR is that if the chosen index state is in the latest index state, then the URI will not contained the suffix `@timestamp` both when the change made by the user is from dropdown or address bar.

This PR has only able to solve only number 1 above. I'll still try to understand how the changes in URI works using reflex and reflex-dom.

Maybe @benkolera have another in mind on how to handle the number 2 and 3 above?
