### PR TITLE
Initial  Fix

### DIFF
--- a/src-ui.v3/matrix-ui.cabal
+++ b/src-ui.v3/matrix-ui.cabal
@@ -17,6 +17,7 @@ executable matrix-ui
   main-is: Main.hs
   other-modules: API
                , PkgId
+               , Router
 
   mixins: base hiding (Prelude)
 

--- a/src-ui.v3/src/Main.hs
+++ b/src-ui.v3/src/Main.hs
@@ -65,6 +65,7 @@ import           Reflex.Time
 import           Reflex.Class
 import           Servant.API
 import           Servant.Reflex
+import qualified Text.Read                    as R
 
 import           API
 import           PkgId
@@ -109,7 +110,7 @@ utc2unix x = ceiling (realToFrac (utcTimeToPOSIXSeconds x) :: Double)
 
 bodyElement4 :: forall t m . (SupportsServantReflex t m, MonadFix m, MonadIO m, MonadHold t m, PostBuild t m, DomBuilder t m, Adjustable t m, DomBuilderSpace m ~ GhcjsDomSpace) => m ()
 bodyElement4 = do
-  _ <- runRouteViewT app
+  _ <- runRouteViewT' app
 
   --(result, changeStateE) <- runSetRouteT $ app RouteHome 
   pure ()
@@ -330,15 +331,16 @@ app dynFrag = do
         let dynPkgTags = pkgTagList <$> dynTagPkgs
         packagesPageWidget dynPackages0 dynTags dynPkgTags
 
-    RoutePackage (pn, idxSt) -> do
-
+    RoutePackage (PkgN pkgUri) -> do
+        let pn = PkgN $ T.takeWhile (/='@') pkgUri
+            (intIdx  :: Maybe Int) = R.readMaybe (T.unpack (T.takeWhileEnd (/='@') pkgUri))
+            idxSt = PkgIdxTs $ fromMaybe 0 intIdx
         el "h2" $ text (pkgNToText pn)
         el "p" $ el "em" $ elAttr "a" ("href" =: ("https://hackage.haskell.org/package/" <> pkgNToText pn)) $
           do text "(view on Hackage)"
 
         evPB <- getPostBuild
         let 
-          dynIdxStLast' = fmap (\x -> M.fromMaybe x idxSt) dynIdxStLast
         -- single-shot requests
         evReports <- getPackageReports (constDyn $ Right pn) evPB
         dynReports <- holdDyn mempty evReports
@@ -346,7 +348,7 @@ app dynFrag = do
         evInfo <- getInfo evPB
         dynInfo <- holdDyn (ControllerInfo mempty) evInfo
 
-        evHist <- getPackageHistory (constDyn $ Right pn) (leftmost [updated dynIdxStLast' $> (), evPB])
+        evHist <- getPackageHistory (constDyn $ Right pn) (leftmost [updated dynIdxStLast $> (), evPB])
         dynHist <- holdDyn mempty evHist
 
         evPkgTags <- getPackageTags (constDyn $ Right pn) evPB
@@ -364,28 +366,25 @@ app dynFrag = do
           text " for latest index-state "
           dynText (pkgIdxTsToText <$> dynIdxStLast)
 
-          putQueue (constDyn $ Right pn) (Right <$> dynIdxStLast') (constDyn $ Right (QEntryUpd (-1))) evQButton
-
-
-        let xs = Map.fromList . fmap (\x -> (x, pkgIdxTsToText x)) . Set.toList <$> dynReports
-            x0 = (\s -> if Set.null s then PkgIdxTs 0
-                                      else (findInitialDropDown idxSt s)) <$> dynReports
-            
-
-        let ddCfg = DropdownConfig (updated x0) (constDyn mempty)
+          putQueue (constDyn $ Right pn) (Right <$> dynIdxStLast) (constDyn $ Right (QEntryUpd (-1))) evQButton
 
         let inputAttr = ("class" =: "tag-name") <> ("placeholder" =: "insert tag")
             iCfg = TextInputConfig "tag-name" "" never (constDyn inputAttr)
+        let xs = Map.fromList . fmap (\x -> (x, pkgIdxTsToText x)) . Set.toList <$> dynReports
 
-        ddReports <- el "p" $ do
+        ddReports <- el "p" $ mdo
+          let maxId = findInitialDropDown idxSt <$> dynReports
+              ddCfg = (def :: DropdownConfig t PkgIdxTs)
+                    & dropdownConfig_setValue .~ (updated maxId)
+          initId <- sample $ current maxId
           evQButton <- button "Queue a build"
           text " for the index-state "
-          tmp <- routePkgIdxTs pn (PkgIdxTs 0) dynReports xs ddCfg
+          dd <- dropdown initId xs ddCfg
+          routePkgIdxTs pn dynReports (dd ^. dropdown_value)
           text " shown below"
+          _ <- putQueue (constDyn $ Right pn) (Right <$> _dropdown_value dd) (constDyn $ Right (QEntryUpd (-1))) evQButton
 
-          _ <- putQueue (constDyn $ Right pn) (Right <$> _dropdown_value tmp) (constDyn $ Right (QEntryUpd (-1))) evQButton
-
-          pure tmp
+          pure dd
         
         elClass "p" "tagging" $ mdo
           let evMapTags = Map.fromList . (fmap (\t -> (t,t))) . (fmap tagNToText) . V.toList <$> evPkgTags
@@ -472,7 +471,7 @@ app dynFrag = do
       pure $ (TagN tId) <$ delResult
 
 -- | Renders alpha-tabbed package index
-packagesPageWidget :: forall t m. (MonadFix m, MonadHold t m, PostBuild t m, DomBuilder t m) 
+packagesPageWidget :: forall t m. (SetRoute t FragRoute m, MonadFix m, MonadHold t m, PostBuild t m, DomBuilder t m) 
                    => Dynamic t (Vector PkgN) 
                    -> Dynamic t (Vector TagN) 
                    -> Dynamic t (Map.Map PkgN [TagN])
@@ -516,7 +515,7 @@ packagesPageWidget dynPackages dynTags dynPkgTags = do
                   pure $ do
 
                     el "ol" $ forM_ v' $ \(pn) -> do
-                      el "li" $ elAttr "a" ("href" =: ("#/package/" <> (pkgNToText pn))) $ do
+                      el "li" $ routeLink False ("#/package/" <> (pkgNToText pn)) $ do
                         text ((pkgNToText pn) <> " : ")
                         case Map.lookup pn dpt of
                           Just tags -> forM tags $ \(tag0) -> elAttr "a" (("class" =: "tag-item") <> ("data-tag-name" =: (tagNToText tag0))) $ text (tagNToText tag0)
@@ -531,7 +530,7 @@ packagesPageWidget dynPackages dynTags dynPkgTags = do
       V.filter (tagContained st dpt) pkg
 
 
-reportTableWidget :: forall t m . (MonadHold t m, PostBuild t m, DomBuilder t m, Reflex t)
+reportTableWidget :: forall t m . (SetRoute t FragRoute m, MonadHold t m, PostBuild t m, DomBuilder t m, Reflex t)
                   => Dynamic t PkgIdxTsReport
                   -> Dynamic t (Vector QEntryRow)
                   -> Dynamic t (Vector WorkerRow)
@@ -603,7 +602,7 @@ reportTableWidget dynRepSum dynQRows dynWorkers dynHist dynInfo = joinE =<< go
 
                 elAttr "th" ("style" =: "text-align:left;") (text (verToText pv))
                 el "td" $ text (pkgIdxTsToText t)
-                el "td" $ elAttr "a" ("href" =: ("#/user/" <> u)) (text u)
+                el "td" $ routeLink False ("#/user/" <> u) (text u)
 
                 pure (leftmost evsRow1)
             pure (leftmost evsRows) -- main "return" value
@@ -701,11 +700,14 @@ applyLR (L:xs)  (l:ls)    rs  = l : applyLR xs ls rs
 applyLR (R:xs)     ls  (r:rs) = r : applyLR xs ls rs
 applyLR _ _ _                 = error "applyLR"
 
-findInitialDropDown :: Maybe PkgIdxTs -> Set PkgIdxTs -> PkgIdxTs
-findInitialDropDown (Just idx) pkgSet = if Set.member idx pkgSet 
-                                        then Set.foldr (\a b -> if a == b then a else b) idx pkgSet
-                                        else Set.findMax pkgSet
-findInitialDropDown Nothing pkgSet    = Set.findMax pkgSet
+findInitialDropDown :: PkgIdxTs -> Set PkgIdxTs -> PkgIdxTs
+findInitialDropDown p s
+  | True <- Set.null s
+  = PkgIdxTs 0
+  | otherwise = if Set.member p s then p else Set.findMax s
+  {-if Set.null s 
+  then PkgIdxTs 0
+  else Set.findMax s-}
 
 toggleTagSet :: TagN -> Set.Set TagN -> Set.Set TagN
 toggleTagSet tn st = if Set.member tn st then Set.delete tn st else Set.insert tn st
@@ -778,7 +780,7 @@ calcMatches pkgs sJss
     textS                = JSS.textFromJSString sJss
     (exactMap,othersMap) = F.foldMap (calcMatch sJss) pkgs
 
-searchBoxWidget :: forall t m. (SupportsServantReflex t m, MonadFix m, MonadIO m, MonadHold t m, PostBuild t m, DomBuilder t m, Adjustable t m, DomBuilderSpace m ~ GhcjsDomSpace)
+searchBoxWidget :: forall t m. (SetRoute t FragRoute m, SupportsServantReflex t m, MonadFix m, MonadIO m, MonadHold t m, PostBuild t m, DomBuilder t m, Adjustable t m, DomBuilderSpace m ~ GhcjsDomSpace)
                 => Dynamic t (Vector PkgN) 
                 -> m ()  
 searchBoxWidget dynPkgs0 = mdo
@@ -794,16 +796,17 @@ searchBoxWidget dynPkgs0 = mdo
   clickPkgE <- searchResultWidget matchesDyn
   pure ()
 
-searchResultWidget :: forall t m. (MonadFix m, MonadHold t m, PostBuild t m, DomBuilder t m) 
+searchResultWidget :: forall t m. (SetRoute t FragRoute m, MonadFix m, MonadHold t m, PostBuild t m, DomBuilder t m) 
                    => Dynamic t Matches 
                    -> m (Event t Text)
 searchResultWidget mDyn =
   el "ul" $ do
     exactE <- listViewWithKey (matchesExact <$> mDyn) $ \eId _ -> do
-                (e, _) <- element "li" def $ elAttr "a" ("href" =: ("#/package/" <> eId)) $ el "strong" $ text eId
+                (e, _) <- element "li" def $ 
+                  routeLink False ("#/package/" <> eId) $ el "strong" $ text eId
                 pure $ domEvent Click e
     otherE <- listViewWithKey (matchesInfix <$> mDyn) $ \pId txt -> do
-                (e, _) <- element "li" def $ elAttr "a" ("href" =: ("#/package/" <> pId)) $ do
+                (e, _) <- element "li" def $ routeLink False ("#/package/" <> pId) $ do
                             dynText . fmap (^. _1) $ txt
                             el "strong" $ dynText . fmap (^. _2) $ txt
                             dynText . fmap (^. _3) $ txt

--- a/src-ui.v3/src/Main.hs
+++ b/src-ui.v3/src/Main.hs
@@ -110,7 +110,7 @@ utc2unix x = ceiling (realToFrac (utcTimeToPOSIXSeconds x) :: Double)
 
 bodyElement4 :: forall t m . (SupportsServantReflex t m, MonadFix m, MonadIO m, MonadHold t m, PostBuild t m, DomBuilder t m, Adjustable t m, DomBuilderSpace m ~ GhcjsDomSpace) => m ()
 bodyElement4 = do
-  _ <- runRouteViewT' app
+  _ <- runRouteViewT app
 
   --(result, changeStateE) <- runSetRouteT $ app RouteHome 
   pure ()

--- a/src-ui.v3/src/Router.hs
+++ b/src-ui.v3/src/Router.hs
@@ -33,7 +33,8 @@ module Router
   , routeLink
   , routePkgIdxTs
   , runRouteViewT
-  , FragRoute(..), decodeFrag
+  , runRouteViewT'
+  , FragRoute(..), decodeFrag, encodeFrag
   ) where
 
 import           Prelude hiding ((.), id)
@@ -45,7 +46,6 @@ import           Control.Monad.Reader
 import           Control.Monad.Ref
 import qualified Data.Char                 as C
 import           Data.Coerce
-import qualified Data.Map.Strict           as Map
 import           Data.Monoid
 import           Data.Proxy
 import qualified Data.Set                  as Set
@@ -60,11 +60,16 @@ import           Reflex.PerformEvent.Class
 import           Reflex.EventWriter.Class
 import           Reflex.EventWriter.Base
 import           Reflex.Dom.Builder.Class
-import           Language.Javascript.JSaddle
+import           Language.Javascript.JSaddle (MonadJSM, jsNull)
 import           Reflex.Dom.Core
-import qualified GHCJS.DOM.Types as DOM
-import qualified GHCJS.DOM.Window as Window
 import qualified GHCJS.DOM as DOM
+import qualified GHCJS.DOM.WindowEventHandlers as DOM
+import qualified GHCJS.DOM.EventM as DOM
+import           GHCJS.DOM.Types (History, Window, SerializedScriptValue (..), liftJSM, fromJSVal, toJSVal)
+import qualified GHCJS.DOM.Window as Window
+import qualified GHCJS.DOM.History as History
+import qualified GHCJS.DOM.Location as Location
+import qualified GHCJS.DOM.PopStateEvent as PopStateEvent
 import           Network.URI
 import           Data.Maybe (Maybe(..), fromMaybe)
 
@@ -73,7 +78,7 @@ import           PkgId
 data FragRoute = RouteHome
                | RouteQueue
                | RoutePackages
-               | RoutePackage (PkgN, Maybe PkgIdxTs)
+               | RoutePackage PkgN
                | RouteUser UserName
                | RouteUnknown T.Text
                deriving (Eq, Ord)
@@ -176,36 +181,25 @@ routeLink False r w = do
 
 routePkgIdxTs :: forall t m. (PostBuild t m, MonadHold t m, MonadFix m, DomBuilder t m, SetRoute t FragRoute m) 
               => PkgN
-              -> PkgIdxTs
               -> Dynamic t (Set PkgIdxTs)
-              -> Dynamic t (Map.Map PkgIdxTs Text) 
-              -> DropdownConfig t PkgIdxTs
-              -> m (Dropdown t PkgIdxTs)
-routePkgIdxTs pn k0 setIdx opt ddConf = do
-  dd <- dropdown k0 opt ddConf
-  let evDD = updated $ ffor2 setIdx (dd ^. dropdown_value) (\sId dVal -> createRoutePackage pn sId dVal)
-      --defIdx = RoutePackage (pn, Nothing)
+              -> Dynamic t PkgIdxTs
+              -> m ()
+routePkgIdxTs pn setIdx ddIdx = do
+  let evDD = updated $ ffor2 setIdx ddIdx (\sId dVal -> createRoutePackage pn sId dVal)
   setRoute $ switchPkgRoute <$> evDD
-  pure dd
+  pure ()
 
 createRoutePackage :: PkgN -> Set PkgIdxTs -> PkgIdxTs -> Maybe FragRoute
 createRoutePackage _ _ (PkgIdxTs 0) = Nothing
-createRoutePackage pn setIdx pkgIdx
+createRoutePackage (PkgN pn) setIdx pkgIdx
   | Just maxIdx <- Set.lookupMax setIdx
   , True     <- maxIdx /= pkgIdx
-  = Just $ RoutePackage (pn, Just pkgIdx)
-  | otherwise = Just $ RoutePackage (pn, Nothing)
-
-switchHistoryItem :: HistoryCommand -> HistoryItem -> HistoryItem
-switchHistoryItem hC hI
-  | (HistoryCommand_PushState su) <- hC
-  , (Just uri) <- _historyStateUpdate_uri su
-  = hI { _historyItem_uri = uri }
-  | otherwise = hI 
+  = Just $ RoutePackage (PkgN $ T.append pn (cons '@' $ idxTsToText pkgIdx))
+  | otherwise = Just $ RoutePackage (PkgN pn)
 
 runRouteViewT  :: forall t m. (Adjustable t m, TriggerEvent t m, PerformEvent t m, MonadHold t m, MonadJSM m, MonadJSM (Performable m), MonadFix m)
                => (FragRoute -> SetRouteT t FragRoute m ())
-               -> m (Dynamic t (Maybe Text))
+               -> m () --(Dynamic t (Maybe Text))
 runRouteViewT app = mdo
   historyState <- manageHistory $ HistoryCommand_PushState <$> setState
 
@@ -215,21 +209,71 @@ runRouteViewT app = mdo
     route :: Dynamic t FragRoute
     route = decodeFrag . T.pack . uriFragment <$> dynLoc
 
-    setState = fmapMaybe id $ attachWith switchRoutingState ( (,) <$> current historyState <*> current route) changeStateE
+    setState = attachWithMaybe switchRoutingState ( (,) <$> current historyState <*> current route) changeStateE
   (result, changeStateE) <- runSetRouteT $ strictDynWidget_ app route
-  pure (encodeFrag <$> route)
+  pure result
+
+runRouteViewT'  :: forall t m. (MonadJSM m, Adjustable t m, TriggerEvent t m, PerformEvent t m, MonadHold t m, MonadFix m, MonadJSM (Performable m))
+               => (FragRoute -> SetRouteT t FragRoute m ())
+               -> m () --(Dynamic t (Maybe Text))
+runRouteViewT' app = mdo
+  window <- DOM.currentWindowUnchecked
+  history <- Window.getHistory window
+  location <- Window.getLocation window
+  oldUri <- (decodeFrag . T.pack . uriFragment) <$> getLocationUri location
+  backState <- wrapDomEvent window (`DOM.on` DOM.popState) $ do
+    e <- DOM.event
+    jV <- PopStateEvent.getState e
+    oUri <- liftJSM $ fromJSVal jV
+    pure $ decodeFrag $ fromMaybe (T.pack "") oUri
+  setState <- performEvent $ attachWith (switchRoutingState' history) (current route) changeStateE
+  route <- foldDynMaybe switchFrag oldUri $ setState
+  (result, changeStateE) <- runSetRouteT $ strictDynWidget_ app route
+  pure result
+
+switchFrag :: FragRoute -> FragRoute -> Maybe FragRoute
+switchFrag newFrag oldFrag
+  | True <- newFrag == oldFrag
+  = Nothing
+  | (RoutePackage _) <- newFrag
+  , (RoutePackage _) <- oldFrag
+  = Just newFrag
+  | otherwise = Just newFrag
+
+{-backRoutingState :: (MonadJSM m) => History -> m FragRoute
+backRoutingState hs = wrapDomEvent window (`DOM.on` DOM.popState) $ do
+  e <- DOM.event
+  jV <- PopStateEvent.getState e
+  oUri <- liftJSM $ fromJSVal jV
+  pure $ decodeFrag $ fromMaybe (T.pack "") oUri
+-}
+switchRoutingState' :: (MonadJSM m) => History -> FragRoute -> Endo FragRoute -> m FragRoute
+switchRoutingState' hs oldR chStateE = do
+  let newRoute' = appEndo chStateE oldR
+      newRoute  = encodeFrag newRoute'
+      oldRoute  = fromMaybe (T.pack "") $ encodeFrag oldR
+      histRoute = fromMaybe (T.pack "") $ newRoute
+
+  newState <- liftJSM $ toJSVal histRoute
+  History.pushState hs 
+                    (SerializedScriptValue newState)
+                    histRoute
+                    (applyEncoding' oldRoute newRoute)
+  pure newRoute'
 
 switchRoutingState :: (HistoryItem, FragRoute) -> Endo FragRoute -> Maybe HistoryStateUpdate
 switchRoutingState (currentHS, oldR) chStateE = -- chState :: Endo (FragRoute -> FragRoute)
-  let newRoute = encodeFrag $ appEndo chStateE oldR
-  in do
-      oldRoute <- encodeFrag oldR
-      newUri   <- applyEncoding oldRoute newRoute (_historyItem_uri currentHS)
-      pure $ HistoryStateUpdate
-             { _historyStateUpdate_state = DOM.SerializedScriptValue jsNull
-             , _historyStateUpdate_title = ""
-             , _historyStateUpdate_uri   = Just newUri
-             }
+  let newR     = appEndo chStateE oldR
+      switchF  = switchFrag newR oldR
+      oldRoute = fromMaybe (T.pack "") $ encodeFrag oldR
+      
+  in case switchF of
+    Nothing -> Nothing
+    Just nR -> Just $ HistoryStateUpdate
+                       { _historyStateUpdate_state = SerializedScriptValue jsNull
+                       , _historyStateUpdate_title = ""
+                       , _historyStateUpdate_uri   = applyEncoding oldRoute nR (_historyItem_uri currentHS)
+                       }
 
 switchPkgRoute :: Maybe FragRoute -> FragRoute -> FragRoute
 switchPkgRoute newFrag oldFrag = fromMaybe oldFrag newFrag
@@ -238,17 +282,20 @@ encodeFrag :: FragRoute -> Maybe Text
 encodeFrag RouteHome = Just "#/"
 encodeFrag RouteQueue = Just "#/queue"
 encodeFrag RoutePackages = Just "#/packages"
-encodeFrag (RoutePackage (pkg, maybeIndex))
-  | Just indexTs <- maybeIndex
-    = Just $ "#/package/" <> (pkgNToText pkg) <> "@" <> (idxTsToText indexTs)
-  | otherwise = Just $ "#/package/" <> (pkgNToText pkg)
+encodeFrag (RoutePackage (PkgN pkg)) = Just $ "#/package/" <> pkg
 encodeFrag (RouteUser usr) = Just $ "#/user/" <> usr
 encodeFrag (RouteUnknown _) = Nothing
 
-applyEncoding :: Text -> Maybe Text -> URI -> Maybe URI
-applyEncoding _ Nothing _ = Nothing
-applyEncoding oldR (Just newR) u 
-  | oldR /= newR = Just $ u { uriFragment = T.unpack newR }
+applyEncoding' :: Text -> Maybe Text -> Maybe Text
+applyEncoding' _ Nothing = Nothing
+applyEncoding' oldR (Just newR)
+  | oldR /= newR = Just $ newR
+  | otherwise    = Nothing
+
+applyEncoding :: Text -> FragRoute -> URI -> Maybe URI
+applyEncoding oldR r u 
+  | Just newR <- encodeFrag r
+  , oldR /= newR = Just $ u { uriFragment = T.unpack newR }
   | otherwise    = Nothing
 
 decodeFrag :: T.Text -> FragRoute
@@ -261,8 +308,8 @@ decodeFrag frag = case frag of
 
     _ | Just sfx <- T.stripPrefix "#/package/" frag
       , not (T.null frag)
-      , (Just pn, idx) <- pkgNFromText sfx
-        -> RoutePackage (pn , idx)
+      , Just pn <- pkgNFromText sfx
+        -> RoutePackage pn
 
       | Just sfx <- T.stripPrefix "#/user/" frag
       , not (T.null frag)


### PR DESCRIPTION
This is an initial fix for removing `dyn`. The purpose is to prevent page loading while changing the package's index-state. Even though this initial PR still not fix the issue yet, the loading page performance improved.

