### PR TITLE
Use same logo as hackage

### DIFF
--- a/src-ui.v2/src/Container.purs
+++ b/src-ui.v2/src/Container.purs
@@ -116,7 +116,7 @@ ui =
                 [ HP.classes (H.ClassName <$> ["item","left","logo-container","clearfix"]) ]
                 [ HH.img
                     [ HP.class_ (H.ClassName "logo")
-                    , HP.src "//www.haskell.org/static/img/logo.png"
+                    , HP.src "//hackage.haskell.org/static/icons/ic_haskell_grayscale_32.svg"
                     , HP.alt "Haskell Logo"
                     ]
                 , HH.h1

--- a/ui.v2/style.css
+++ b/ui.v2/style.css
@@ -71,7 +71,7 @@ body {
 
 #menu .logo {
   height: 43px;
-  width: 64px;
+  width: 43px;
   float: left;
 }
 #menu .logo-text {


### PR DESCRIPTION
It seems that http://www.haskell.org/static/img/logo.png is dead, and I
couldn't easily find that file on the new hackage.org page. So as a
relatively quick fix, this makes it use the same logo as hackage.